### PR TITLE
Fix MLIR context lifetime and parameter handling

### DIFF
--- a/AI/include/Utils/tensor_utils.hpp
+++ b/AI/include/Utils/tensor_utils.hpp
@@ -5,20 +5,19 @@
 #include "Environment/quantum_circuit_tensor.hpp"
 
 // MLIR includes
-#include "mlir/IR/BuiltinOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-
+#include "mlir/IR/BuiltinOps.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Libtorch c10::ArrayRef conflicts with llvm::ArrayRef included in the mlir
 /// namespace, so every mlir type has to be included seperately.
-using mlir::ModuleOp;
-using mlir::func::FuncOp;
+using mlir::Location;
 using mlir::MLIRContext;
+using mlir::ModuleOp;
+using mlir::OpBuilder;
 using mlir::Operation;
 using mlir::Value;
-using mlir::OpBuilder;
-using mlir::Location;
+using mlir::func::FuncOp;
 ////////////////////////////////////////////////////////////////////////////////
 
 namespace ai_pass_selector {
@@ -46,8 +45,7 @@ Operation *findReturn(ModuleOp m);
  * @param isAdjoint
  * @return
  */
-std::string gateIdFor(
-    const std::string &base, int numControls, bool isAdjoint);
+std::string gateIdFor(const std::string &base, int numControls, bool isAdjoint);
 
 /**
  *
@@ -56,8 +54,8 @@ std::string gateIdFor(
  * @param angles
  * @return
  */
-std::vector<Value>
-anglesToValues(OpBuilder &b, Location loc, llvm::ArrayRef<double> angles);
+std::vector<Value> anglesToValues(OpBuilder &b, Location loc,
+                                  llvm::ArrayRef<double> angles);
 
 /**
  *
@@ -66,14 +64,13 @@ anglesToValues(OpBuilder &b, Location loc, llvm::ArrayRef<double> angles);
  */
 static int activeGateIndex(const double *base);
 
-
 /**
  *
  * @param tensor
  * @return
  */
 ModuleOp recreateQuantumCircuitFromInstructionBasedTensor(
-    const InstructionBasedTensor<double> &tensor);
+    MLIRContext &ctx, const InstructionBasedTensor<double> &tensor);
 
 /**
  *
@@ -81,7 +78,7 @@ ModuleOp recreateQuantumCircuitFromInstructionBasedTensor(
  * @return
  */
 ModuleOp recreateQuantumCircuitFromDepthBasedTensor(
-    const DepthBasedTensor<double> &tensor);
+    MLIRContext &ctx, const DepthBasedTensor<double> &tensor);
 
 } // namespace ai_pass_selector
 

--- a/AI/src/Utils/conversion_workflow.cpp
+++ b/AI/src/Utils/conversion_workflow.cpp
@@ -1,6 +1,7 @@
 #include "Utils/conversion_workflow.hpp"
 
 // MLIR includes
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/Passes.h"
 
@@ -17,14 +18,14 @@
 #include "Environment/environment.hpp"
 #include "Utils/tensor_utils.hpp"
 
-#include <vector>
 #include <cstdlib>
 #include <filesystem>
-#include <functional>
 #include <fstream>
+#include <functional>
 #include <iostream>
 #include <string.h>
 #include <sys/wait.h>
+#include <vector>
 
 namespace fs = std::filesystem;
 using namespace mqss::opt;
@@ -40,13 +41,13 @@ int run_shell_command(const std::string &command, const std::string &task) {
   try {
     return_code = std::system(command.c_str());
   } catch (const std::exception &e) {
-    std::cerr << "\nException running " << task << ": " << e.what() <<
-        std::endl;
+    std::cerr << "\nException running " << task << ": " << e.what()
+              << std::endl;
     return -1;
   }
   if (return_code != 0) {
-    std::cerr << "\n" << task
-        << " failed (return code: " << return_code << ")\n";
+    std::cerr << "\n"
+              << task << " failed (return code: " << return_code << ")\n";
     return return_code;
   }
   return 0;
@@ -57,25 +58,24 @@ bool copy_file_and_report(const fs::path &source, const fs::path &destination) {
   fs::create_directories(destination.parent_path(), error_code);
   if (!fs::copy_file(source, destination, fs::copy_options::overwrite_existing,
                      error_code)) {
-    std::cerr << "\nFailed to copy " << source.string()
-        << " to " << destination.string()
-        << (error_code ? ": " + error_code.message() : "") << std::endl;
+    std::cerr << "\nFailed to copy " << source.string() << " to "
+              << destination.string()
+              << (error_code ? ": " + error_code.message() : "") << std::endl;
     return false;
   }
   return true;
 }
 
-int convert_quake_to_tikz(
-    const fs::path &quake_to_tikz_tool_path, const fs::path &quake_input_path,
-    const fs::path &tikz_output_path, const std::string &append_to_log_file) {
-  const std::string command_line =
-      quake_to_tikz_tool_path.string() +
-      " --input " + quake_input_path.string() +
-      " --output " + tikz_output_path.string() +
-      " >> " + append_to_log_file;
-  return run_shell_command(
-      command_line,
-      "Conversion qke → tikz for " + quake_input_path.string());
+int convert_quake_to_tikz(const fs::path &quake_to_tikz_tool_path,
+                          const fs::path &quake_input_path,
+                          const fs::path &tikz_output_path,
+                          const std::string &append_to_log_file) {
+  const std::string command_line = quake_to_tikz_tool_path.string() +
+                                   " --input " + quake_input_path.string() +
+                                   " --output " + tikz_output_path.string() +
+                                   " >> " + append_to_log_file;
+  return run_shell_command(command_line, "Conversion qke → tikz for " +
+                                             quake_input_path.string());
 }
 
 int write_module_to_file(ModuleOp module,
@@ -86,8 +86,8 @@ int write_module_to_file(ModuleOp module,
 
   std::ofstream output_file(destination_file_path.string());
   if (!output_file) {
-    std::cerr << "\nFailed to open " << destination_file_path.string() <<
-        std::endl;
+    std::cerr << "\nFailed to open " << destination_file_path.string()
+              << std::endl;
     return -1;
   }
   output_file << module_serialized_text;
@@ -99,17 +99,18 @@ int build_png_from_tikz_file(const fs::path &tikz_file_path) {
   // Minimal wrapper document (standalone) that \input{sometikz.tikz}
   // Write temp.tex next to CWD (consistent with existing workflow).
   {
-    const std::string latex_wrapper =
-        "\\documentclass{standalone}\n"
-        "\\usepackage{tikz}\n"
-        "\\usetikzlibrary{quantikz}\n"
-        "\\begin{document}\n"
-        "\\input{" + tikz_file_path.string() + "}\n"
-        "\\end{document}\n";
+    const std::string latex_wrapper = "\\documentclass{standalone}\n"
+                                      "\\usepackage{tikz}\n"
+                                      "\\usetikzlibrary{quantikz}\n"
+                                      "\\begin{document}\n"
+                                      "\\input{" +
+                                      tikz_file_path.string() +
+                                      "}\n"
+                                      "\\end{document}\n";
     std::ofstream temp_tex_file("temp.tex");
     if (!temp_tex_file) {
-      std::cerr << "\nFailed to create temp.tex for " << tikz_file_path <<
-          std::endl;
+      std::cerr << "\nFailed to create temp.tex for " << tikz_file_path
+                << std::endl;
       return -1;
     }
     temp_tex_file << latex_wrapper;
@@ -122,13 +123,13 @@ int build_png_from_tikz_file(const fs::path &tikz_file_path) {
   const std::string command_line =
       "pdflatex -interaction=nonstopmode temp.tex > /dev/null 2>&1 && "
       "convert -density 300 -strip temp.pdf -trim -quality 90 " +
-      png_output_base + ".png > /dev/null 2>&1 && "
+      png_output_base +
+      ".png > /dev/null 2>&1 && "
       "rm temp.* > /dev/null 2>&1";
 
-  return run_shell_command(
-      command_line, "PNG conversion for " + tikz_file_path.string());
+  return run_shell_command(command_line,
+                           "PNG conversion for " + tikz_file_path.string());
 }
-
 
 // ------------------------------------------------------------
 // Dataset-wide QASM → Quake conversion (unchanged in behavior)
@@ -169,7 +170,7 @@ int convertQasmDatasetToQuake(const std::string &subdirectory) {
   fs::create_directories(quake_dir);
   if (!fs::exists(qasm_dir)) {
     std::cerr << "Input directory does not exist: " << qasm_dir.string()
-        << std::endl;
+              << std::endl;
     return -1;
   }
 
@@ -177,23 +178,23 @@ int convertQasmDatasetToQuake(const std::string &subdirectory) {
   for (const auto &entry : fs::directory_iterator(qasm_dir)) {
     if (!entry.is_regular_file()) {
       std::cout << "Rejecting conversion qasm->quake for: " << entry
-          << " because it's not a regular file." << std::endl;
+                << " because it's not a regular file." << std::endl;
       continue;
     }
     if (entry.path().extension() != ".qasm") {
       std::cout << "Rejecting conversion qasm->quake for: " << entry
-          << " because extension is not .qasm." << std::endl;
+                << " because extension is not .qasm." << std::endl;
       continue;
     }
     total++;
   }
   if (total == 0) {
     std::cout << "No .qasm files found for qasm to quake conversion."
-        << std::endl;
+              << std::endl;
     return -1;
   }
   std::cout << "Converting " << total << " Qasm circuits to Quake from "
-      << quake_dir.string() << " dataset." << std::endl;
+            << quake_dir.string() << " dataset." << std::endl;
 
   int current = 0;
   for (const auto &entry : fs::directory_iterator(qasm_dir)) {
@@ -210,11 +211,11 @@ int convertQasmDatasetToQuake(const std::string &subdirectory) {
         ret = std::system(cmd.c_str());
       } catch (const std::exception &e) {
         std::cerr << "\nException on " << input << ": " << e.what()
-            << std::endl;
+                  << std::endl;
       }
       if (ret != 0) {
         std::cerr << "\nConversion failed for " << input
-            << " (return code: " << ret << ")" << std::endl;
+                  << " (return code: " << ret << ")" << std::endl;
         return -1;
       }
 
@@ -225,14 +226,12 @@ int convertQasmDatasetToQuake(const std::string &subdirectory) {
   return 0;
 }
 
-
 // ------------------------------------------------------------
 // Passtest → TikZ PNGs
 // ------------------------------------------------------------
 void convertAllPasstestCircuitsToTikz() {
   std::vector<
-        std::tuple<std::string, std::function<std::unique_ptr<mlir::Pass>()> >
-      >
+      std::tuple<std::string, std::function<std::unique_ptr<mlir::Pass>()>>>
       passes = {
           {"ZeroRxToId", [] { return createZeroRxToIdPass(); }},
           {"ZeroRyToId", [] { return createZeroRyToIdPass(); }},
@@ -298,12 +297,11 @@ void convertAllPasstestCircuitsToTikz() {
           {"SToSdgSdgSdg", [] { return createSToSdgSdgSdgPass(); }},
           {"SToTT", [] { return createSToTTPass(); }},
           {"SwapToLowerCxCxCx", [] { return createSwapToLowerCxCxCxPass(); }},
-          {"SwapToUpperCxCxCx",
-           [] { return createSwapToUpperCxCxCxPass(); }}};
+          {"SwapToUpperCxCxCx", [] { return createSwapToUpperCxCxCxPass(); }}};
 
   const int total = static_cast<int>(passes.size());
   std::cout << "Converting " << total << " quake passtest circuits to tikz."
-      << std::endl;
+            << std::endl;
 
   if (total == 0) {
     std::cout << "No passes found for conversion to TikZ." << std::endl;
@@ -312,11 +310,11 @@ void convertAllPasstestCircuitsToTikz() {
 
   try {
     fs::create_directories("./logs");
-    std::string cmd =
-        "echo \"passtest_to_tikz_before.log:\n\" > ./logs/passtest_to_tikz_before.log";
+    std::string cmd = "echo \"passtest_to_tikz_before.log:\n\" > "
+                      "./logs/passtest_to_tikz_before.log";
     std::system(cmd.c_str());
-    cmd =
-        "echo \"passtest_to_tikz_after.log:\n\" > ./logs/passtest_to_tikz_after.log";
+    cmd = "echo \"passtest_to_tikz_after.log:\n\" > "
+          "./logs/passtest_to_tikz_after.log";
     std::system(cmd.c_str());
   } catch (const fs::filesystem_error &e) {
     std::cerr << "\nError creating directory: " << e.what() << std::endl;
@@ -334,7 +332,7 @@ void convertAllPasstestCircuitsToTikz() {
     waitpid(child_pid, &status, 0);
     if (WIFSIGNALED(status)) {
       std::cerr << "\nPass: " << passname << " crashed with signal "
-          << strsignal(WTERMSIG(status)) << std::endl;
+                << strsignal(WTERMSIG(status)) << std::endl;
       break;
     }
     updateProgress(++current, total, "");
@@ -344,17 +342,18 @@ void convertAllPasstestCircuitsToTikz() {
   const fs::path latex_dir = fs::path(AI_DATASET_DIR) / "Latex";
   const fs::path tex_file = latex_dir / "passtest_quantum_circuits.tex";
   const std::string compile_pdf =
-      "pdflatex -interaction=nonstopmode -halt-on-error --shell-escape -output-directory="
-      + latex_dir.string() + " " + tex_file.string() + " > /dev/null 2>&1";
+      "pdflatex -interaction=nonstopmode -halt-on-error --shell-escape "
+      "-output-directory=" +
+      latex_dir.string() + " " + tex_file.string() + " > /dev/null 2>&1";
   std::cout << "Compiling LaTeX file to PDF." << std::endl;
   if (const int ret = std::system(compile_pdf.c_str()); ret != 0) {
     std::cerr << "\nPDF generation failed for passtest_quantum_circuits.tex "
-        << "(return code: " << ret << ")" << std::endl;
+              << "(return code: " << ret << ")" << std::endl;
     return;
   }
   std::cout << "PDF generated successfully at "
-      << (latex_dir / "passtest_quantum_circuits.pdf").string()
-      << std::endl;
+            << (latex_dir / "passtest_quantum_circuits.pdf").string()
+            << std::endl;
 }
 
 int convertPasstestCircuitToTikz(std::string passname,
@@ -381,16 +380,15 @@ int convertPasstestCircuitToTikz(std::string passname,
   }
 
   if (int rc = convert_quake_to_tikz(
-      quake_to_tikz_tool_path,
-      latex_quake_input_file,
-      latex_tikz_input_file,
-      "./logs/passtest_to_tikz_before.log"); rc != 0) {
+          quake_to_tikz_tool_path, latex_quake_input_file,
+          latex_tikz_input_file, "./logs/passtest_to_tikz_before.log");
+      rc != 0) {
     return -1;
   }
 
   // Load, run pass pipeline, write out
-  std::string quake_module_text = readFileToString(
-      quake_source_input_file.string());
+  std::string quake_module_text =
+      readFileToString(quake_source_input_file.string());
   auto [mlir_module, context_ptr] = extractMLIRContext(quake_module_text);
   MLIRContext &context = *context_ptr;
   mlir::PassManager pass_manager(&context);
@@ -398,20 +396,19 @@ int convertPasstestCircuitToTikz(std::string passname,
   pass_manager.addPass(mlir::createCanonicalizerPass());
   pass_manager.addPass(mlir::createCSEPass());
   if (mlir::failed(pass_manager.run(mlir_module))) {
-    std::cerr << "\nThe pass failed for " << quake_source_input_file.string() <<
-        std::endl;
+    std::cerr << "\nThe pass failed for " << quake_source_input_file.string()
+              << std::endl;
     return -1;
   }
   if (int rc = write_module_to_file(mlir_module, latex_quake_output_file);
-    rc != 0) {
+      rc != 0) {
     return -1;
   }
 
   if (int rc = convert_quake_to_tikz(
-      quake_to_tikz_tool_path,
-      latex_quake_output_file,
-      latex_tikz_output_file,
-      "./logs/passtest_to_tikz_after.log"); rc != 0) {
+          quake_to_tikz_tool_path, latex_quake_output_file,
+          latex_tikz_output_file, "./logs/passtest_to_tikz_after.log");
+      rc != 0) {
     return -1;
   }
 
@@ -425,27 +422,26 @@ int convertPasstestCircuitToTikz(std::string passname,
   return 0;
 }
 
-
 // ------------------------------------------------------------
 // Tensortest → TikZ PNGs (refactored, same behavior)
 // ------------------------------------------------------------
 void convertAllTensortestCircuitsToTikz(int nrTensortestCircuits) {
   std::cout << "Converting " << nrTensortestCircuits
-      << " quake tensortest circuits to tikz." << std::endl;
+            << " quake tensortest circuits to tikz." << std::endl;
   if (nrTensortestCircuits == 0) {
     std::cout << "No circuits found for conversion to TikZ." << std::endl;
     return;
   }
   try {
     fs::create_directories("./logs");
-    std::string cmd =
-        "echo \"tensortest_to_tikz_before.log:\n\" > ./logs/tensortest_to_tikz_before.log";
+    std::string cmd = "echo \"tensortest_to_tikz_before.log:\n\" > "
+                      "./logs/tensortest_to_tikz_before.log";
     std::system(cmd.c_str());
-    cmd =
-        "echo \"tensortest_to_tikz_after1.log:\n\" > ./logs/tensortest_to_tikz_after1.log";
+    cmd = "echo \"tensortest_to_tikz_after1.log:\n\" > "
+          "./logs/tensortest_to_tikz_after1.log";
     std::system(cmd.c_str());
-    cmd =
-        "echo \"tensortest_to_tikz_after2.log:\n\" > ./logs/tensortest_to_tikz_after2.log";
+    cmd = "echo \"tensortest_to_tikz_after2.log:\n\" > "
+          "./logs/tensortest_to_tikz_after2.log";
     std::system(cmd.c_str());
   } catch (const fs::filesystem_error &e) {
     std::cerr << "\nError creating directory: " << e.what() << std::endl;
@@ -462,9 +458,8 @@ void convertAllTensortestCircuitsToTikz(int nrTensortestCircuits) {
     int status;
     waitpid(child_pid, &status, 0);
     if (WIFSIGNALED(status)) {
-      std::cerr << "\nCircuit: tensortest" << current
-          << " crashed with signal " << strsignal(WTERMSIG(status))
-          << std::endl;
+      std::cerr << "\nCircuit: tensortest" << current << " crashed with signal "
+                << strsignal(WTERMSIG(status)) << std::endl;
       break;
     }
     updateProgress(current, nrTensortestCircuits, "");
@@ -473,24 +468,25 @@ void convertAllTensortestCircuitsToTikz(int nrTensortestCircuits) {
   const fs::path latex_dir = fs::path(AI_DATASET_DIR) / "Latex";
   const fs::path tex_file = latex_dir / "tensortest_quantum_circuits.tex";
   const std::string compile_pdf =
-      "pdflatex -interaction=nonstopmode -halt-on-error --shell-escape -output-directory="
-      + latex_dir.string() + " " + tex_file.string() + " > /dev/null 2>&1";
+      "pdflatex -interaction=nonstopmode -halt-on-error --shell-escape "
+      "-output-directory=" +
+      latex_dir.string() + " " + tex_file.string() + " > /dev/null 2>&1";
   std::cout << "Compiling LaTeX file to PDF." << std::endl;
   if (const int ret = std::system(compile_pdf.c_str()); ret != 0) {
     std::cerr << "\nPDF generation failed for tensortest_quantum_circuits.tex "
-        << "(return code: " << ret << ")" << std::endl;
+              << "(return code: " << ret << ")" << std::endl;
     return;
   }
   std::cout << "PDF generated successfully at "
-      << (latex_dir / "tensortest_quantum_circuits.pdf").string()
-      << std::endl;
+            << (latex_dir / "tensortest_quantum_circuits.pdf").string()
+            << std::endl;
 }
 
 int convertTensortestCircuitToTikz(int index) {
   std::string circuit_name = "tensortest" + std::to_string(index);
-  const fs::path quake_source_input_file =
-      fs::path(AI_DATASET_DIR) / "Quake/Tensortest" / (
-        circuit_name + "_input.qke");
+  const fs::path quake_source_input_file = fs::path(AI_DATASET_DIR) /
+                                           "Quake/Tensortest" /
+                                           (circuit_name + "_input.qke");
 
   const fs::path latex_tensortest_dir =
       fs::path(AI_DATASET_DIR) / "Latex/Tensortest";
@@ -516,66 +512,68 @@ int convertTensortestCircuitToTikz(int index) {
     return -1;
   }
   if (int rc = convert_quake_to_tikz(
-      quake_to_tikz_tool_path,
-      latex_quake_input_file,
-      latex_tikz_input_file,
-      "./logs/tensortest_to_tikz_before.log"); rc != 0) {
+          quake_to_tikz_tool_path, latex_quake_input_file,
+          latex_tikz_input_file, "./logs/tensortest_to_tikz_before.log");
+      rc != 0) {
     return -1;
   }
 
   // Build instruction/depth observations and reconstruct two modules
-  std::string quake_module_text = readFileToString(
-      quake_source_input_file.string());
+  std::string quake_module_text =
+      readFileToString(quake_source_input_file.string());
   auto [input_module, ctx_ptr] = extractMLIRContext(quake_module_text);
 
   QuantumCircuitEnviorment quantum_circuit_enviorment(
-      TENSORTEST_MAX_QUBITS, TENSORTEST_MAX_INSTRUCTIONS,
-      TENSORTEST_MAX_DEPTH, input_module);
+      TENSORTEST_MAX_QUBITS, TENSORTEST_MAX_INSTRUCTIONS, TENSORTEST_MAX_DEPTH,
+      input_module);
   std::cout << "\nBlock 1" << std::endl;
 
-  InstructionBasedTensor<double> instruction_based_observation
-      = quantum_circuit_enviorment.get_instruction_based_observation();
+  InstructionBasedTensor<double> instruction_based_observation =
+      quantum_circuit_enviorment.get_instruction_based_observation();
   std::cout << "\nBlock 2" << std::endl;
 
-  DepthBasedTensor<double> depth_based_observation
-      = quantum_circuit_enviorment.get_depth_based_observation();
+  DepthBasedTensor<double> depth_based_observation =
+      quantum_circuit_enviorment.get_depth_based_observation();
   std::cout << "\nBlock 3" << std::endl;
+
+  auto ctx_owner_for_recon = cudaq::initializeMLIR();
+  MLIRContext &recon_ctx = *ctx_owner_for_recon;
 
   ModuleOp reconstructed_from_instruction_tensor =
       recreateQuantumCircuitFromInstructionBasedTensor(
-          instruction_based_observation);
+          recon_ctx, instruction_based_observation);
   std::cout << "\nBlock 4" << std::endl;
 
   ModuleOp reconstructed_from_depth_tensor =
-      recreateQuantumCircuitFromDepthBasedTensor(depth_based_observation);
+      recreateQuantumCircuitFromDepthBasedTensor(recon_ctx,
+                                                 depth_based_observation);
   std::cout << "\nBlock 5" << std::endl;
 
-  if (int rc = write_module_to_file(
-      reconstructed_from_instruction_tensor,
-      latex_quake_output_file1); rc != 0) {
+  if (int rc = write_module_to_file(reconstructed_from_instruction_tensor,
+                                    latex_quake_output_file1);
+      rc != 0) {
     return -1;
   }
   std::cout << "\nBlock 6" << std::endl;
 
-  if (int rc = write_module_to_file(
-      reconstructed_from_depth_tensor, latex_quake_output_file2); rc != 0) {
+  if (int rc = write_module_to_file(reconstructed_from_depth_tensor,
+                                    latex_quake_output_file2);
+      rc != 0) {
     return -1;
   }
   std::cout << "\nBlock 7" << std::endl;
 
   // Reconstructed quake → tikz (two variants)
   if (int rc = convert_quake_to_tikz(
-      quake_to_tikz_tool_path,
-      latex_quake_output_file1,
-      latex_tikz_output_file1,
-      "./logs/tensortest_to_tikz_after1.log"); rc != 0) {
+          quake_to_tikz_tool_path, latex_quake_output_file1,
+          latex_tikz_output_file1, "./logs/tensortest_to_tikz_after1.log");
+      rc != 0) {
     return -1;
   }
   if (int rc = convert_quake_to_tikz(
-      quake_to_tikz_tool_path,
-      latex_quake_output_file2,
-      latex_tikz_output_file2,
-      "./logs/tensortest_to_tikz_after2.log"); rc != 0) {
+          quake_to_tikz_tool_path, latex_quake_output_file2,
+          latex_tikz_output_file2, "./logs/tensortest_to_tikz_after2.log");
+      rc != 0) {
     return -1;
   }
 

--- a/AI/src/Utils/tensor_utils.cpp
+++ b/AI/src/Utils/tensor_utils.cpp
@@ -2,29 +2,30 @@
 #include "Utils/tensor_utils.hpp"
 
 // Quake + helpers
-#include "Support/CodeGen/Quake.hpp"
 #include "Interfaces/QASMToQuake.hpp"
-#include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
+#include "Support/CodeGen/Quake.hpp"
 #include "cudaq/Optimizer/Dialect/CC/CCTypes.h"
+#include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
 
 // Core MLIR
-#include "mlir/IR/BuiltinOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
 
-#include <queue>
 #include <common/RuntimeMLIR.h>
+#include <queue>
+#include <string_view>
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Libtorch c10::ArrayRef conflicts with llvm::ArrayRef included in the mlir
 /// namespace, so every mlir type has to be included seperately.
-using mlir::ModuleOp;
-using mlir::Value;
-using mlir::OpBuilder;
 using mlir::Location;
+using mlir::MLIRContext;
+using mlir::ModuleOp;
+using mlir::OpBuilder;
 using mlir::Operation;
 using mlir::SmallVector;
 using mlir::Type;
-using mlir::MLIRContext;
+using mlir::Value;
 using mlir::func::FuncOp;
 using mlir::func::ReturnOp;
 ////////////////////////////////////////////////////////////////////////////////
@@ -57,8 +58,8 @@ Operation *findReturn(ModuleOp m) {
   return ret;
 }
 
-std::string gateIdFor(
-    const std::string &base, int numControls, bool isAdjoint) {
+std::string gateIdFor(const std::string &base, int numControls,
+                      bool isAdjoint) {
   // Measurements (no controls)
   if (base == "mx" || base == "my" || base == "mz")
     return base;
@@ -74,15 +75,12 @@ std::string gateIdFor(
     return numControls == 1 ? "ch" : "h";
 
   if (base == "s")
-    return numControls == 1
-             ? (isAdjoint ? "csdg" : "cs")
-             : isAdjoint
-             ? "sdg"
-             : "s";
+    return numControls == 1 ? (isAdjoint ? "csdg" : "cs")
+           : isAdjoint      ? "sdg"
+                            : "s";
   if (base == "t")
-    return numControls == 1
-             ? (isAdjoint ? "ctdg" : "ct")
-             : (isAdjoint ? "tdg" : "t");
+    return numControls == 1 ? (isAdjoint ? "ctdg" : "ct")
+                            : (isAdjoint ? "tdg" : "t");
 
   if (base == "rx")
     return numControls == 1 ? "crx" : "rx";
@@ -111,13 +109,26 @@ std::string gateIdFor(
 }
 
 // Turn angles[] (double) -> MLIR Value list (f64 constants).
-std::vector<Value>
-anglesToValues(OpBuilder &b, Location loc, llvm::ArrayRef<double> angles) {
+std::vector<Value> anglesToValues(OpBuilder &b, Location loc,
+                                  llvm::ArrayRef<double> angles) {
   std::vector<Value> vals;
   vals.reserve(angles.size());
   for (double a : angles)
     vals.push_back(mqss::support::quakeDialect::createFloatValue(b, loc, a));
   return vals;
+}
+
+// Return the number of angle parameters expected for a given base gate.
+static int expectedAngleCountForBase(std::string_view base) {
+  if (base == "rx" || base == "ry" || base == "rz" || base == "r1")
+    return 1;
+  if (base == "u2")
+    return 2;
+  if (base == "u3" || base == "u")
+    return 3;
+  if (base == "phased_rx" || base == "r")
+    return 2;
+  return 0;
 }
 
 // Read which gate is active in an instruction row/cell.
@@ -128,15 +139,13 @@ static int activeGateIndex(const double *base) {
   return -1;
 }
 
-} // namespace
+} // namespace ai_pass_selector
 
 // ------------------------ Instruction-based ------------------------
 ModuleOp ai_pass_selector::recreateQuantumCircuitFromInstructionBasedTensor(
-    const InstructionBasedTensor<double> &tensor) {
-  auto ctxPtr = cudaq::initializeMLIR(); // keep the owner alive
-  auto &ctx = *ctxPtr; // safe reference
-  ModuleOp module = makeEmptyModuleWithKernel(
-      ctx, "__nvqpp__mlirgen__FromTensor");
+    MLIRContext &ctx, const InstructionBasedTensor<double> &tensor) {
+  ModuleOp module =
+      makeEmptyModuleWithKernel(ctx, "__nvqpp__mlirgen__FromTensor");
   OpBuilder builder(&ctx);
   Location loc = builder.getUnknownLoc();
 
@@ -188,24 +197,51 @@ ModuleOp ai_pass_selector::recreateQuantumCircuitFromInstructionBasedTensor(
 
     // Params
     bool isAdjoint = (row[paramOffset] != 0.0);
+    int need = expectedAngleCountForBase(baseGate);
     std::vector<double> angles;
-    for (int i = 0; i < MAX_GATE_ANGLES; ++i)
-      if (row[paramOffset + 1 + i] != 0.0)
-        angles.push_back(row[paramOffset + 1 + i]);
+    angles.reserve(need);
+    for (int i = 0; i < need; ++i)
+      angles.push_back(row[paramOffset + 1 + i]);
 
     // Build refs
     std::vector<Value> controlRefs, targetRefs;
     controlRefs.reserve(controlsIdx.size());
     targetRefs.reserve(targetsIdx.size());
     for (int c : controlsIdx)
-      controlRefs.push_back(
-          builder.create<quake::ExtractRefOp>(loc, veq,
-                                              static_cast<std::size_t>(c)));
+      controlRefs.push_back(builder.create<quake::ExtractRefOp>(
+          loc, veq, static_cast<std::size_t>(c)));
     for (int t : targetsIdx)
-      targetRefs.push_back(
-          builder.create<quake::ExtractRefOp>(loc, veq,
-                                              static_cast<std::size_t>(t)));
+      targetRefs.push_back(builder.create<quake::ExtractRefOp>(
+          loc, veq, static_cast<std::size_t>(t)));
     std::vector<Value> paramVals = anglesToValues(builder, loc, angles);
+
+    // Measurements are handled directly since the QASM gate map lacks mx/my/mz
+    if ((baseGate == "mx" || baseGate == "my" || baseGate == "mz") &&
+        controlRefs.empty() && targetRefs.size() == 1) {
+      Value qref = targetRefs[0];
+      std::vector<Value> empty;
+      std::vector<Value> tRef{qref};
+      if (baseGate == "mx") {
+        mqss::interfaces::insertQASMGateIntoQuakeModule(
+            "h", builder, loc, empty, empty, tRef, false);
+        builder.create<quake::MzOp>(loc, qref);
+        mqss::interfaces::insertQASMGateIntoQuakeModule(
+            "h", builder, loc, empty, empty, tRef, false);
+      } else if (baseGate == "my") {
+        mqss::interfaces::insertQASMGateIntoQuakeModule(
+            "sdg", builder, loc, empty, empty, tRef, false);
+        mqss::interfaces::insertQASMGateIntoQuakeModule(
+            "h", builder, loc, empty, empty, tRef, false);
+        builder.create<quake::MzOp>(loc, qref);
+        mqss::interfaces::insertQASMGateIntoQuakeModule(
+            "h", builder, loc, empty, empty, tRef, false);
+        mqss::interfaces::insertQASMGateIntoQuakeModule(
+            "s", builder, loc, empty, empty, tRef, false);
+      } else {
+        builder.create<quake::MzOp>(loc, qref);
+      }
+      continue;
+    }
 
     // Choose concrete gate id
     std::string gateId =
@@ -219,26 +255,23 @@ ModuleOp ai_pass_selector::recreateQuantumCircuitFromInstructionBasedTensor(
   return module;
 }
 
-
 // ------------------------ Depth-based ------------------------
 ModuleOp ai_pass_selector::recreateQuantumCircuitFromDepthBasedTensor(
-    const DepthBasedTensor<double> &tensor) {
+    MLIRContext &ctx, const DepthBasedTensor<double> &tensor) {
   const int maxDepth = tensor.shape[0];
   const int maxQubits = tensor.shape[1];
   const int features = tensor.shape[2];
 
-  const int expectedFeatures = NR_GATES + MAX_GATE_PARAMS + CONTROL_PARAMS +
-                               maxQubits;
+  const int expectedFeatures =
+      NR_GATES + MAX_GATE_PARAMS + CONTROL_PARAMS + maxQubits;
   if (features != expectedFeatures) {
     throw std::runtime_error("Depth tensor feature width mismatch: features=" +
-                             std::to_string(features) + " expected=" +
-                             std::to_string(expectedFeatures));
+                             std::to_string(features) +
+                             " expected=" + std::to_string(expectedFeatures));
   }
 
-  auto ctxPtr = cudaq::initializeMLIR();
-  auto &ctx = *ctxPtr;
-  ModuleOp module = makeEmptyModuleWithKernel(
-      ctx, "__nvqpp__mlirgen__FromTensor");
+  ModuleOp module =
+      makeEmptyModuleWithKernel(ctx, "__nvqpp__mlirgen__FromTensor");
   OpBuilder builder(&ctx);
   Location loc = builder.getUnknownLoc();
 
@@ -260,7 +293,7 @@ ModuleOp ai_pass_selector::recreateQuantumCircuitFromDepthBasedTensor(
 
   // Scratch to avoid re-extracting the same ref many times
   std::vector refCache(maxQubits, Value{});
-  auto getRef = [&](int q)-> Value {
+  auto getRef = [&](int q) -> Value {
     if (!refCache[q])
       refCache[q] = builder.create<quake::ExtractRefOp>(
           loc, veq, static_cast<std::size_t>(q));
@@ -282,8 +315,8 @@ ModuleOp ai_pass_selector::recreateQuantumCircuitFromDepthBasedTensor(
 
     bool anyAtThisDepth = false;
     for (int q = 0; q < maxQubits; ++q) {
-      const double *base = tensor.raw() + (depth * tensor.shape[1] + q) *
-                           features;
+      const double *base =
+          tensor.raw() + (depth * tensor.shape[1] + q) * features;
       int g = activeGateIndex(base + feature_gate_offset);
       if (g < 0) {
         continue;
@@ -295,10 +328,10 @@ ModuleOp ai_pass_selector::recreateQuantumCircuitFromDepthBasedTensor(
       cells[q].isTarget = base[feature_control_info_offset + 1] != 0.0;
       cells[q].isAdjoint = base[feature_param_offset + 0] != 0.0;
 
-      for (int i = 0; i < MAX_GATE_ANGLES; ++i) {
-        if (double v = base[feature_param_offset + 1 + i]; v != 0.0)
-          cells[q].angles.push_back(v);
-      }
+      int need = expectedAngleCountForBase(SUPPORTED_GATES[g]);
+      cells[q].angles.reserve(need);
+      for (int i = 0; i < need; ++i)
+        cells[q].angles.push_back(base[feature_param_offset + 1 + i]);
       for (int t = 0; t < maxQubits; ++t) {
         if (base[feature_targets_offset + t] != 0.0)
           cells[q].linkedQubits.push_back(t);
@@ -308,7 +341,7 @@ ModuleOp ai_pass_selector::recreateQuantumCircuitFromDepthBasedTensor(
       continue;
 
     // Group qubits by gate index
-    std::unordered_map<int, std::vector<int> > qubitsByGate;
+    std::unordered_map<int, std::vector<int>> qubitsByGate;
     for (int q = 0; q < maxQubits; ++q) {
       if (cells[q].gateIndex >= 0) {
         qubitsByGate[cells[q].gateIndex].push_back(q);
@@ -351,8 +384,8 @@ ModuleOp ai_pass_selector::recreateQuantumCircuitFromDepthBasedTensor(
           for (int v : members) {
             if (!visited[v] && cells[v].gateIndex == gate) {
               if (std::find(cells[v].linkedQubits.begin(),
-                            cells[v].linkedQubits.end(), u)
-                  != cells[v].linkedQubits.end()) {
+                            cells[v].linkedQubits.end(),
+                            u) != cells[v].linkedQubits.end()) {
                 visited[v] = 1;
                 q.push(v);
               }
@@ -383,8 +416,7 @@ ModuleOp ai_pass_selector::recreateQuantumCircuitFromDepthBasedTensor(
         // Special-case: two-target, no-control gates like SWAP
         if (baseGate == "swap" && controls.empty() && targets.size() == 2) {
           std::vector<Value> emptyParams, emptyCtrls;
-          std::vector tRefs = {getRef(targets[0]),
-                               getRef(targets[1])};
+          std::vector<Value> tRefs{getRef(targets[0]), getRef(targets[1])};
           mqss::interfaces::insertQASMGateIntoQuakeModule(
               "swap", builder, loc, emptyParams, emptyCtrls, tRefs, false);
           continue;
@@ -401,9 +433,8 @@ ModuleOp ai_pass_selector::recreateQuantumCircuitFromDepthBasedTensor(
         }
 
         // Controlled ops (support common 1c/1t, and some known 2c/1t X)
-        std::string gateId = gateIdFor(baseGate,
-                                       static_cast<int>(controls.size()),
-                                       isAdjoint);
+        std::string gateId =
+            gateIdFor(baseGate, static_cast<int>(controls.size()), isAdjoint);
         auto params = anglesToValues(builder, loc, angles);
 
         // If multiple targets exist (e.g., separate CXs at same depth),
@@ -415,19 +446,19 @@ ModuleOp ai_pass_selector::recreateQuantumCircuitFromDepthBasedTensor(
             std::vector<Value> ctrlsForThisTarget;
             for (int c : controls) {
               bool linked = std::find(cells[c].linkedQubits.begin(),
-                                      cells[c].linkedQubits.end(), t)
-                            != cells[c].linkedQubits.end();
+                                      cells[c].linkedQubits.end(),
+                                      t) != cells[c].linkedQubits.end();
               // also accept symmetric link from target back to control
               linked = linked || std::find(cells[t].linkedQubits.begin(),
-                                           cells[t].linkedQubits.end(), c)
-                       != cells[t].linkedQubits.end();
+                                           cells[t].linkedQubits.end(),
+                                           c) != cells[t].linkedQubits.end();
               if (linked)
                 ctrlsForThisTarget.push_back(getRef(c));
             }
             if (ctrlsForThisTarget.empty())
               continue;
 
-            std::vector tRef = {getRef(t)};
+            std::vector<Value> tRef{getRef(t)};
             mqss::interfaces::insertQASMGateIntoQuakeModule(
                 gateId, builder, loc, params, ctrlsForThisTarget, tRef,
                 isAdjoint);
@@ -436,15 +467,31 @@ ModuleOp ai_pass_selector::recreateQuantumCircuitFromDepthBasedTensor(
         }
 
         // Measurements: emit one op per target qubit
-        if ((baseGate == "mx" || baseGate == "my" || baseGate == "mz")
-            && controls.empty() && !targets.empty()) {
+        if ((baseGate == "mx" || baseGate == "my" || baseGate == "mz") &&
+            controls.empty() && !targets.empty()) {
           for (int t : targets) {
-            std::vector<Value> emptyParams, emptyCtrls;
-            std::vector tRef = {getRef(t)};
-            mqss::interfaces::insertQASMGateIntoQuakeModule(
-                baseGate, builder, loc,
-                emptyParams, emptyCtrls, tRef,
-                /*isAdjoint*/false);
+            Value qref = getRef(t);
+            std::vector<Value> empty;
+            std::vector<Value> tRef{qref};
+            if (baseGate == "mx") {
+              mqss::interfaces::insertQASMGateIntoQuakeModule(
+                  "h", builder, loc, empty, empty, tRef, false);
+              builder.create<quake::MzOp>(loc, qref);
+              mqss::interfaces::insertQASMGateIntoQuakeModule(
+                  "h", builder, loc, empty, empty, tRef, false);
+            } else if (baseGate == "my") {
+              mqss::interfaces::insertQASMGateIntoQuakeModule(
+                  "sdg", builder, loc, empty, empty, tRef, false);
+              mqss::interfaces::insertQASMGateIntoQuakeModule(
+                  "h", builder, loc, empty, empty, tRef, false);
+              builder.create<quake::MzOp>(loc, qref);
+              mqss::interfaces::insertQASMGateIntoQuakeModule(
+                  "h", builder, loc, empty, empty, tRef, false);
+              mqss::interfaces::insertQASMGateIntoQuakeModule(
+                  "s", builder, loc, empty, empty, tRef, false);
+            } else {
+              builder.create<quake::MzOp>(loc, qref);
+            }
           }
           continue;
         }


### PR DESCRIPTION
## Summary
- Avoid destroying MLIRContext when reconstructing circuits by taking a context reference
- Preserve zero-valued rotation parameters and handle expected angle counts
- Add explicit measurement handling for mx/my/mz during tensor reconstruction

## Testing
- `pip install pre-commit` *(failed: Could not find a version that satisfies the requirement pre-commit)*
- `ctest` *(failed: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c845b73083329ced111ec0b4e424