### PR TITLE
Accept .qke circuits in agent utils and add tests

### DIFF
--- a/AI/include/Utils/info_utils.hpp
+++ b/AI/include/Utils/info_utils.hpp
@@ -32,6 +32,18 @@ std::optional<std::tuple<fs::path, std::string, std::string> >
 search_circuit(const std::string &circuit_file);
 
 /**
+ * Resolve a circuit lookup result into a usable Quake file path.
+ * @param circuit_folder Absolute directory that contains the circuit.
+ * @param circuit_name   Circuit basename (without extension).
+ * @param circuit_extension Original extension returned by search_circuit.
+ * @return The full path to a Quake (.qke) file when available.
+ */
+std::optional<fs::path> prepare_circuit_input_path(
+    const fs::path &circuit_folder,
+    const std::string &circuit_name,
+    const std::string &circuit_extension);
+
+/**
  *
  * @param circuit_file
  * @return

--- a/AI/src/Torch/agent_utils.cpp
+++ b/AI/src/Torch/agent_utils.cpp
@@ -100,12 +100,12 @@ getRecommendedPasses(
     return {};
   }
   auto [path, name, extension] = found_circuit.value();
-  if (extension != ".quake") {
-    std::cerr << "Invalid circuit: "
-        << path / (name + extension) << std::endl;
+  auto input_path_optional
+      = prepare_circuit_input_path(path, name, extension);
+  if (!input_path_optional.has_value()) {
     return {};
   }
-  fs::path input_path = path / (name + extension);
+  fs::path input_path = input_path_optional.value();
   std::vector<std::unique_ptr<mlir::Pass> > passes;
   std::vector<std::string> pass_names;
   std::vector<unsigned int> pass_indexes;

--- a/AI/src/Utils/info_utils.cpp
+++ b/AI/src/Utils/info_utils.cpp
@@ -60,6 +60,32 @@ search_circuit(const std::string &circuit_file) {
   return std::nullopt;
 }
 
+std::optional<fs::path> prepare_circuit_input_path(
+    const fs::path &circuit_folder,
+    const std::string &circuit_name,
+    const std::string &circuit_extension) {
+  fs::path circuit_path = circuit_folder / (circuit_name + circuit_extension);
+  if (circuit_extension == ".qke") {
+    if (!fs::exists(circuit_path)) {
+      std::cerr << "Circuit file not found: " << circuit_path << std::endl;
+      return std::nullopt;
+    }
+    return circuit_path;
+  }
+  if (circuit_extension == ".qasm") {
+    const std::string qasm_to_quake_tool_path
+        = std::string(MQSS_BUILD_DIR) + "/tools/qasm-to-quake";
+    std::cerr << "Circuit " << circuit_path
+        << " uses '.qasm'. Convert it to '.qke' first (e.g. with "
+        << qasm_to_quake_tool_path << ") before requesting passes."
+        << std::endl;
+    return std::nullopt;
+  }
+  std::cerr << "Unsupported circuit extension '" << circuit_extension
+      << "'. Expected a '.qke' circuit." << std::endl;
+  return std::nullopt;
+}
+
 std::optional<std::tuple<
   std::string, std::string,
   unsigned int, unsigned int, unsigned int> >

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -129,6 +129,14 @@ target_include_directories(
           ${CUDAQ_MLIR_RUNTIME_PATH})
 add_test(NAME Test-QASM-parser-correctness COMMAND test-qasm-parser-correctness)
 
+if (TARGET ai_core)
+  add_executable(test-ai-info-utils testAIInfoUtils.cpp)
+  target_link_libraries(test-ai-info-utils PRIVATE ai_core ${GTEST_LIBRARIES})
+  target_compile_definitions(
+    test-ai-info-utils PRIVATE MQSS_TEST_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
+  add_test(NAME Test-ai-info-utils COMMAND test-ai-info-utils)
+endif ()
+
 set(TEST_OUTPUT_DIR $<TARGET_FILE_DIR:test-mqss-passes>/golden-cases)
 add_custom_target(
   copy-golden-cases ALL

--- a/tests/testAIInfoUtils.cpp
+++ b/tests/testAIInfoUtils.cpp
@@ -1,0 +1,38 @@
+#include <gtest/gtest.h>
+
+#include <Utils/info_utils.hpp>
+
+#include <filesystem>
+#include <string>
+
+namespace fs = std::filesystem;
+
+TEST(AIInfoUtilsTest, ResolveQuakeCircuitFromSearchResult) {
+  const fs::path quake_file =
+      fs::path(MQSS_TEST_SOURCE_DIR) / "tests/quake/ZeroRxToIdPass.qke";
+  auto result = ai_pass_selector::prepare_circuit_input_path(
+      quake_file.parent_path(), quake_file.stem().string(),
+      quake_file.extension().string());
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), quake_file);
+}
+
+TEST(AIInfoUtilsTest, RejectsUnsupportedExtensions) {
+  const fs::path invalid_file =
+      fs::path(MQSS_TEST_SOURCE_DIR) / "tests/quake/ZeroRxToIdPass.qke";
+  auto result = ai_pass_selector::prepare_circuit_input_path(
+      invalid_file.parent_path(), invalid_file.stem().string(), ".txt");
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST(AIInfoUtilsTest, RejectsQasmAndHintsConversion) {
+  const fs::path qasm_file =
+      fs::path(MQSS_TEST_SOURCE_DIR) / "tests/qasm/test-parser.qasm";
+  testing::internal::CaptureStderr();
+  auto result = ai_pass_selector::prepare_circuit_input_path(
+      qasm_file.parent_path(), qasm_file.stem().string(),
+      qasm_file.extension().string());
+  std::string stderr_output = testing::internal::GetCapturedStderr();
+  EXPECT_FALSE(result.has_value());
+  EXPECT_NE(stderr_output.find(".qke"), std::string::npos);
+}


### PR DESCRIPTION
## Summary
- allow getRecommendedPasses to reuse a helper that accepts .qke circuits and reports when a .qasm file needs conversion
- add the new helper in info_utils and ensure diagnostics steer users toward qasm-to-quake
- register a GoogleTest exercising the .qke handling for AI info utilities and wire it into the tests build when ai_core is available

## Testing
- cmake -S . -B build *(fails: missing MLIRConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68caf2896dfc833298e67f1679e9075e