### PR TITLE
Add bounds check for parallel environment registration

### DIFF
--- a/AI/include/Torch/parallel_environments.hpp
+++ b/AI/include/Torch/parallel_environments.hpp
@@ -35,10 +35,13 @@ namespace ai_pass_selector {
         ParallelEnvironments &operator=(ParallelEnvironments &&) noexcept = default;
 
         /**
+         * Registers a circuit in the environment identified by @p index.
+         * The provided @p index must be smaller than size(); otherwise, a
+         * std::out_of_range exception is thrown.
          *
-         * @param index
-         * @param circuit_path
-         * @return
+         * @param index        Environment slot that should own the circuit.
+         * @param circuit_path Path to the circuit that should be registered.
+         * @return True if the circuit could be registered successfully.
          */
         bool register_quantum_circuit(
             unsigned int index, const fs::path &circuit_path);

--- a/AI/src/Torch/parallel_environments.cpp
+++ b/AI/src/Torch/parallel_environments.cpp
@@ -1,6 +1,8 @@
 #include "Torch/parallel_environments.hpp"
 
 #include <future>
+#include <stdexcept>
+#include <string>
 
 namespace ai_pass_selector {
 ParallelEnvironments::ParallelEnvironments(
@@ -23,6 +25,13 @@ ParallelEnvironments::ParallelEnvironments(
 
 bool ParallelEnvironments::register_quantum_circuit(
     unsigned int index, const fs::path &circuit_path) {
+  if (index >= nr_environments) {
+    throw std::out_of_range(
+        "ParallelEnvironments::register_quantum_circuit: index "
+        + std::to_string(index)
+        + " is out of range for " + std::to_string(nr_environments)
+        + " environments");
+  }
   return environments[index].register_quantum_circuit(circuit_path);
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,6 +52,13 @@ target_link_libraries(test-transpiler PRIVATE ${COMMON_LIBRARIES})
 target_include_directories(test-transpiler PRIVATE ${CMAKE_SOURCE_DIR}/include
                                                    ${CUDAQ_MLIR_RUNTIME_PATH})
 
+if (TARGET ai_torch)
+  add_executable(test-parallel-environments testParallelEnvironments.cpp)
+  target_link_libraries(test-parallel-environments PRIVATE ${COMMON_LIBRARIES}
+                                                           ai_torch)
+  add_test(NAME Test-parallel-environments COMMAND test-parallel-environments)
+endif ()
+
 add_executable(test-verification-qcec testMQSS-QCEC.cpp)
 target_link_libraries(test-verification-qcec PRIVATE ${COMMON_LIBRARIES}
                                                      MQT::QCEC MLIRPasses)

--- a/tests/testParallelEnvironments.cpp
+++ b/tests/testParallelEnvironments.cpp
@@ -1,0 +1,20 @@
+#include "Torch/parallel_environments.hpp"
+
+#include <filesystem>
+#include <gtest/gtest.h>
+#include <stdexcept>
+
+namespace fs = std::filesystem;
+
+TEST(ParallelEnvironmentsTest, RegisterQuantumCircuitRejectsInvalidIndex) {
+  ai_pass_selector::ParallelEnvironments environments(
+      /*nr_environments=*/1,
+      /*max_qubits=*/1,
+      /*max_instructions=*/1,
+      /*max_depth=*/1,
+      /*max_steps=*/1);
+
+  EXPECT_THROW(
+      environments.register_quantum_circuit(/*index=*/1, fs::path{}),
+      std::out_of_range);
+}


### PR DESCRIPTION
## Summary
- add an explicit bounds check to `ParallelEnvironments::register_quantum_circuit` and document the requirement in the public header
- extend the tests CMake configuration to build a new guard-focused test when Torch support is available
- add a regression test that verifies an out-of-range index triggers the guard

## Testing
- `cmake -S . -B build -DBUILD_MLIR_PASSES_AI=ON -DBUILD_MLIR_PASSES_TESTS=ON -DBUILD_MLIR_PASSES_DOCS=OFF -DBUILD_MLIR_PASSES_TOOLS=OFF` *(fails: unable to download googletest through the proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68caf28ea44c8332872ab50e8b19e9f9