### PR TITLE
Align tensor angles parameter type

### DIFF
--- a/AI/include/Utils/tensor_utils.hpp
+++ b/AI/include/Utils/tensor_utils.hpp
@@ -4,6 +4,8 @@
 
 #include "Environment/quantum_circuit_tensor.hpp"
 
+#include "llvm/ADT/ArrayRef.h"
+
 // MLIR
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinOps.h"

--- a/AI/src/Utils/tensor_utils.cpp
+++ b/AI/src/Utils/tensor_utils.cpp
@@ -50,7 +50,7 @@ Operation *findReturn(ModuleOp module) {
 }
 
 std::vector<Value> anglesToValues(OpBuilder &builder, Location loc,
-                                  const std::vector<double> &angles) {
+                                  llvm::ArrayRef<double> angles) {
   std::vector<Value> vals;
   vals.reserve(angles.size());
   for (double angle : angles) {


### PR DESCRIPTION
## Summary
- include llvm ArrayRef header in tensor_utils.hpp
- change anglesToValues implementation to accept llvm::ArrayRef<double> to match declaration

## Testing
- ./build.sh *(fails: unable to access https://github.com/NVIDIA/cuda-quantum.git/ due to 403 CONNECT tunnel failure)*

------
https://chatgpt.com/codex/tasks/task_e_68caf2a92ac48332af259b5147e9c3fa