### PR TITLE
Add kernel entrypoint resolver and guard AI helpers

### DIFF
--- a/AI/include/Utils/circuit_utils.hpp
+++ b/AI/include/Utils/circuit_utils.hpp
@@ -3,9 +3,12 @@
 
 #include <array>
 #include <filesystem>
-#include <vector>
-#include <string>
 #include <limits>
+#include <string>
+#include <vector>
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 
 namespace ai_pass_selector {
     /// Circuit specifications [max_qubits, max_instructions, max_depth]
@@ -45,5 +48,15 @@ namespace ai_pass_selector {
      * @return
      */
     std::vector<std::string> split_string(const std::string &s, char delim);
+
+    /**
+     * Locate the kernel entry function within the given module.
+     *
+     * @param module The module that potentially contains kernel definitions.
+     * @return The kernel function, preferring the one marked with the
+     *         `cudaq-entrypoint` attribute. Returns a null FuncOp and emits an
+     *         error diagnostic when no kernel function is present.
+     */
+    mlir::func::FuncOp getKernelEntryPoint(mlir::ModuleOp module);
 } // namespace ai_pass_selector
 #endif // CIRCUIT_UTILS_HPP

--- a/AI/src/Environment/environment.cpp
+++ b/AI/src/Environment/environment.cpp
@@ -2,6 +2,7 @@
 
 // Environment includes
 #include "Environment/quantum_circuit_tensor.hpp"
+#include "Utils/circuit_utils.hpp"
 #include "Utils/passes_utils.hpp"
 
 // MLIR includes
@@ -26,7 +27,6 @@
 /// namespace, so every mlir type has to be included seperately.
 using mlir::ModuleOp;
 using mlir::Operation;
-using mlir::func::FuncOp;
 ////////////////////////////////////////////////////////////////////////////////
 
 using namespace mqss::support::quakeDialect;
@@ -111,7 +111,11 @@ QuantumCircuitEnviorment::get_circuit_info(const ModuleOp &circuit) {
     return {};
   }
   std::unordered_map<std::string, unsigned int> circuit_info;
-  auto [nrQubits, nrGates, depth] = getQubitsInstructionsDepth(FuncOp(circuit));
+  auto kernel = getKernelEntryPoint(circuit);
+  if (!kernel) {
+    return circuit_info;
+  }
+  auto [nrQubits, nrGates, depth] = getQubitsInstructionsDepth(kernel);
   circuit_info["qubits"] = nrQubits;
   circuit_info["gates"] = nrGates;
   circuit_info["depth"] = depth;
@@ -123,18 +127,21 @@ unsigned int QuantumCircuitEnviorment::circuit_invalid_type(
   if (circuit == nullptr) {
     return NO_CIRCUIT;
   }
-  std::unordered_map<std::string, unsigned int> circuit_info
-      = this->get_circuit_info(circuit);
-  if (circuit_info["qubits"] > this->max_qubits) {
+  auto kernel = getKernelEntryPoint(circuit);
+  if (!kernel) {
+    return NO_CIRCUIT;
+  }
+  auto [nrQubits, nrGates, depth] = getQubitsInstructionsDepth(kernel);
+  if (nrQubits > this->max_qubits) {
     return TOO_MANY_QUBITS;
   }
-  if (circuit_info["gates"] > this->max_instructions) {
+  if (nrGates > this->max_instructions) {
     return TOO_MANY_INSTRUCTIONS;
   }
-  if (circuit_info["depth"] > this->max_depth) {
+  if (depth > this->max_depth) {
     return TOO_LARGE_DEPTH;
   }
-  int nrAllocations = getNumberOfAllocations(FuncOp(circuit));
+  int nrAllocations = getNumberOfAllocations(kernel);
   if (nrAllocations <= 0) {
     return NO_QUBIT_ALLOCATIONS;
   }
@@ -200,7 +207,11 @@ QuantumCircuitEnviorment::get_instruction_based_observation() {
   if (this->circuit == nullptr) {
     return observation;
   }
-  const int NR_QUBITS = getNumberOfQubits(FuncOp(this->circuit));
+  auto kernel = getKernelEntryPoint(this->circuit);
+  if (!kernel) {
+    return observation;
+  }
+  const int NR_QUBITS = getNumberOfQubits(kernel);
   if (NR_QUBITS == 0) {
     return observation;
   }
@@ -274,7 +285,11 @@ QuantumCircuitEnviorment::get_depth_based_observation() {
 
   DepthBasedTensor<double> observation(this->max_qubits, this->max_depth);
 
-  const int NR_QUBITS = getNumberOfQubits(FuncOp(this->circuit));
+  auto kernel = getKernelEntryPoint(this->circuit);
+  if (!kernel) {
+    return observation;
+  }
+  const int NR_QUBITS = getNumberOfQubits(kernel);
   if (NR_QUBITS == 0) {
     return observation;
   }

--- a/AI/src/Torch/A2C/a2c_ib_fc_lsd.cpp
+++ b/AI/src/Torch/A2C/a2c_ib_fc_lsd.cpp
@@ -5,6 +5,7 @@
 #include <mlir_utils.hpp>
 #include <Environment/environment.hpp>
 #include <Torch/parallel_environments.hpp>
+#include <Utils/circuit_utils.hpp>
 #include <Utils/info_utils.hpp>
 #include <Utils/passes_utils.hpp>
 #include <Utils/progress_bar.hpp>
@@ -92,9 +93,13 @@ std::unordered_map<std::string, std::string> train_agent(
   std::vector<std::string> filtered_dataset_files;
   for (auto &file : all_dataset_files) {
     std::string quake_module_text = readFileToString(file.string());
-    if (auto [mlir_module, context_ptr] = extractMLIRContext(quake_module_text);
-      getNumberOfQubits(FuncOp(mlir_module)) > max_qubits
-      || getNumberOfGates(FuncOp(mlir_module)) > max_instructions) {
+    auto [mlir_module, context_ptr] = extractMLIRContext(quake_module_text);
+    auto kernel = getKernelEntryPoint(mlir_module);
+    if (!kernel) {
+      continue;
+    }
+    if (getNumberOfQubits(kernel) > max_qubits
+        || getNumberOfGates(kernel) > max_instructions) {
       continue;
     }
     filtered_dataset_files.push_back(file.string());

--- a/AI/src/Torch/A2C/a2c_ib_fc_lsm.cpp
+++ b/AI/src/Torch/A2C/a2c_ib_fc_lsm.cpp
@@ -5,6 +5,7 @@
 
 // Utils includes
 #include <Torch/parallel_environments.hpp>
+#include <Utils/circuit_utils.hpp>
 #include <Utils/info_utils.hpp>
 #include <Utils/passes_utils.hpp>
 #include <Utils/progress_bar.hpp>
@@ -84,9 +85,13 @@ std::unordered_map<std::string, std::string> train_agent(
   std::vector<std::string> filtered_dataset_files;
   for (auto &file : all_dataset_files) {
     std::string quake_module_text = readFileToString(file.string());
-    if (auto [mlir_module, context_ptr] = extractMLIRContext(quake_module_text);
-      getNumberOfQubits(FuncOp(mlir_module)) > max_qubits
-      || getNumberOfGates(FuncOp(mlir_module)) > max_instructions) {
+    auto [mlir_module, context_ptr] = extractMLIRContext(quake_module_text);
+    auto kernel = getKernelEntryPoint(mlir_module);
+    if (!kernel) {
+      continue;
+    }
+    if (getNumberOfQubits(kernel) > max_qubits
+        || getNumberOfGates(kernel) > max_instructions) {
       continue;
     }
     filtered_dataset_files.push_back(file.string());

--- a/AI/src/Torch/agent_utils.cpp
+++ b/AI/src/Torch/agent_utils.cpp
@@ -72,9 +72,12 @@ std::unique_ptr<torch::optim::Optimizer> makeOptimizer(
 
 std::string select_best_agent(const std::string &circuit) {
   auto [module, contex_ptr] = extractMLIRContext(circuit);
-  switch (auto [nrQubits, nrGates, depth]
-        = getQubitsInstructionsDepth(FuncOp(module));
-    classify_circuit(nrQubits, nrGates, depth)) {
+  auto kernel = getKernelEntryPoint(module);
+  if (!kernel) {
+    throw std::runtime_error("No kernel entry function found in circuit.");
+  }
+  auto [nrQubits, nrGates, depth] = getQubitsInstructionsDepth(kernel);
+  switch (classify_circuit(nrQubits, nrGates, depth)) {
   case TINY:
     return "a2c-ib-fc-lsd-5x25x10";
   case SMALL:

--- a/AI/src/Utils/circuit_utils.cpp
+++ b/AI/src/Utils/circuit_utils.cpp
@@ -1,13 +1,13 @@
 #include "Utils/circuit_utils.hpp"
 
-#include <filesystem>
-#include <vector>
+#include <sstream>
 #include <string>
+#include <vector>
 
-namespace fs = std::filesystem;
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Diagnostics.h"
 
 namespace ai_pass_selector {
-
 
 unsigned int classify_circuit(
     unsigned int nr_qubits,
@@ -36,7 +36,6 @@ unsigned int classify_circuit(
   return HUGE;
 }
 
-
 std::vector<std::string> split_string(const std::string &s, char delim) {
   std::vector<std::string> parts;
   std::stringstream ss(s);
@@ -45,6 +44,29 @@ std::vector<std::string> split_string(const std::string &s, char delim) {
     parts.push_back(item);
   }
   return parts;
+}
+
+FuncOp getKernelEntryPoint(ModuleOp module) {
+  if (!module) {
+    return nullptr;
+  }
+
+  FuncOp fallback_kernel;
+  for (FuncOp func : module.getOps<FuncOp>()) {
+    if (func->hasAttr("cudaq-entrypoint")) {
+      return func;
+    }
+    if (!fallback_kernel && func->hasAttr("cudaq-kernel")) {
+      fallback_kernel = func;
+    }
+  }
+
+  if (fallback_kernel) {
+    return fallback_kernel;
+  }
+
+  module.emitError("Failed to locate a cudaq kernel entry function.");
+  return nullptr;
 }
 
 } // namespace ai_pass_selector

--- a/AI/src/Utils/info_utils.cpp
+++ b/AI/src/Utils/info_utils.cpp
@@ -1,6 +1,7 @@
 #include "Utils/info_utils.hpp"
 
 #include "Quake.hpp"
+#include "Utils/circuit_utils.hpp"
 #include "mlir_utils.hpp"
 
 #include <string>
@@ -78,8 +79,11 @@ get_circuit_info(const std::string &circuit_file) {
   std::string quake_module_text
       = readFileToString(full_circuit_path.string());
   auto [mlir_module, context_ptr] = extractMLIRContext(quake_module_text);
-  auto [nrQubits, nrGates, depth] = getQubitsInstructionsDepth(
-      FuncOp(mlir_module));
+  auto kernel = getKernelEntryPoint(mlir_module);
+  if (!kernel) {
+    return std::nullopt;
+  }
+  auto [nrQubits, nrGates, depth] = getQubitsInstructionsDepth(kernel);
 
   return std::make_tuple(circuit_name, full_circuit_path,
                          nrQubits, nrGates, depth);
@@ -186,9 +190,13 @@ get_dataset_info(const std::string &dataset_name) {
         = readFileToString(entry_path.string());
     auto [mlir_module, context_ptr]
         = extractMLIRContext(quake_module_text);
-    unsigned int nr_qubits = getNumberOfQubits(FuncOp(mlir_module));
-    unsigned int nr_gates = getNumberOfGates(FuncOp(mlir_module));
-    unsigned int depth = getCircuitDepth(FuncOp(mlir_module));
+    auto kernel = getKernelEntryPoint(mlir_module);
+    if (!kernel) {
+      continue;
+    }
+    unsigned int nr_qubits = getNumberOfQubits(kernel);
+    unsigned int nr_gates = getNumberOfGates(kernel);
+    unsigned int depth = getCircuitDepth(kernel);
     if (nr_qubits < min_nr_qubits) {
       min_nr_qubits = nr_qubits;
     }


### PR DESCRIPTION
## Summary
- add a utility to locate the CUDA-Q kernel entry function in a module
- guard environment, info, and agent utilities behind the resolved kernel entry point
- ensure training dataset filtering uses kernel statistics before accepting circuits

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68caf268de6c8332933367c75e62c2b9