### PR TITLE
Read circuit file before parsing in environment

### DIFF
--- a/AI/src/Environment/environment.cpp
+++ b/AI/src/Environment/environment.cpp
@@ -64,9 +64,15 @@ bool QuantumCircuitEnviorment::register_quantum_circuit(
     // registration to the future is intended use.
     return false;
   }
+  std::string circuit_mlir = readFileToString(circuit_path.string());
+  if (circuit_mlir.empty()) {
+    std::cerr << "Failed to read circuit file: " << circuit_path
+              << std::endl;
+    return false;
+  }
   this->circuit_path = circuit_path;
   auto [circuit, context_ptr]
-      = extractModuleOpAndContextPointer(circuit_path.string());
+      = extractModuleOpAndContextPointer(circuit_mlir);
   switch (circuit_invalid_type(circuit)) {
   case CIRCUIT_VALID:
     break;


### PR DESCRIPTION
## Summary
- read the circuit file contents before parsing during quantum circuit registration
- abort registration when the circuit file cannot be loaded

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68caf3ccb3988332a40e0288621f9480