### PR TITLE
Allow .qke circuits for AI agent selection

### DIFF
--- a/AI/src/Torch/agent_utils.cpp
+++ b/AI/src/Torch/agent_utils.cpp
@@ -100,8 +100,8 @@ getRecommendedPasses(
     return {};
   }
   auto [path, name, extension] = found_circuit.value();
-  if (extension != ".quake") {
-    std::cerr << "Invalid circuit: "
+  if (extension != ".quake" && extension != ".qke") {
+    std::cerr << "Invalid circuit (expected .quake or .qke): "
         << path / (name + extension) << std::endl;
     return {};
   }


### PR DESCRIPTION
## Summary
- allow the agent utility to accept `.qke` circuits alongside `.quake`
- update the validation error message to list the supported extensions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68caf3cd6b48833280460c9596e6071c