### PR TITLE
Fix Qasm dataset directory check

### DIFF
--- a/AI/src/Utils/info_utils.cpp
+++ b/AI/src/Utils/info_utils.cpp
@@ -233,7 +233,7 @@ void print_dataset_info(const std::string &dataset_name) {
   fs::path quake_dataset_dir = fs::path(AI_DATASET_DIR)
                                / "Quake" / dataset_name;
 
-  if (fs::exists(quake_dataset_dir) && fs::is_directory(quake_dataset_dir)) {
+  if (fs::exists(qasm_dataset_dir) && fs::is_directory(qasm_dataset_dir)) {
     std::cout << "Dataset Quake/" + dataset_name << ":" << std::endl;
     auto dataset_info = get_dataset_info(dataset_name);
     if (!dataset_info.has_value()) {


### PR DESCRIPTION
## Summary
- ensure the Qasm dataset existence check uses the Qasm directory path

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68caf3ce25d88332b9ee38641976cf1e