### PR TITLE
Include sstream in circuit utils

### DIFF
--- a/AI/src/Utils/circuit_utils.cpp
+++ b/AI/src/Utils/circuit_utils.cpp
@@ -1,6 +1,7 @@
 #include "Utils/circuit_utils.hpp"
 
 #include <filesystem>
+#include <sstream>
 #include <vector>
 #include <string>
 


### PR DESCRIPTION
## Summary
- include `<sstream>` in `AI/src/Utils/circuit_utils.cpp` to support string stream usage

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68caf3d0a1a88332abf9292f81272cd6