### PR TITLE
Use signed return type for GATE_INDEX sentinel

### DIFF
--- a/AI/include/Environment/quantum_circuit_tensor.hpp
+++ b/AI/include/Environment/quantum_circuit_tensor.hpp
@@ -33,10 +33,10 @@ namespace ai_pass_selector {
     constexpr unsigned int MAX_GATE_PARAMS = 3;
     constexpr unsigned int QUBIT_ROLE = 1;
 
-    constexpr unsigned int GATE_INDEX(std::string_view gate) {
-        for (unsigned int i = 0; i < NR_GATES; ++i) {
+    constexpr int GATE_INDEX(std::string_view gate) {
+        for (std::size_t i = 0; i < NR_GATES; ++i) {
             if (SUPPORTED_GATES[i] == gate) {
-                return i;
+                return static_cast<int>(i);
             }
         }
         return -1; // not found
@@ -44,7 +44,10 @@ namespace ai_pass_selector {
 
     constexpr std::array<double, NR_GATES> GATE_ONE_HOT(std::string_view gate) {
         std::array<double, NR_GATES> one_hot{};
-        one_hot[static_cast<std::size_t>(GATE_INDEX(gate))] = 1.0;
+        const int gate_index = GATE_INDEX(gate);
+        if (gate_index >= 0) {
+            one_hot[static_cast<std::size_t>(gate_index)] = 1.0;
+        }
         return one_hot;
     }
 


### PR DESCRIPTION
## Summary
- change GATE_INDEX to return a signed int while keeping -1 as the missing gate sentinel
- guard GATE_ONE_HOT assignments with a non-negative check to avoid invalid indexing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68caf3cf16f883329571b8aca8bf0220