### PR TITLE
Add bounds check for register_quantum_circuit

### DIFF
--- a/AI/src/Torch/parallel_environments.cpp
+++ b/AI/src/Torch/parallel_environments.cpp
@@ -23,6 +23,9 @@ ParallelEnvironments::ParallelEnvironments(
 
 bool ParallelEnvironments::register_quantum_circuit(
     unsigned int index, const fs::path &circuit_path) {
+  if (index >= environments.size()) {
+    return false;
+  }
   return environments[index].register_quantum_circuit(circuit_path);
 }
 


### PR DESCRIPTION
## Summary
- add a bounds check before forwarding circuit registration to an environment to prevent out-of-range access

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68caf3d11bb88332bdb715dbbd3d8ccd