### PR TITLE
Add missing standard headers to info utils

### DIFF
--- a/AI/src/Utils/info_utils.cpp
+++ b/AI/src/Utils/info_utils.cpp
@@ -3,9 +3,12 @@
 #include "Quake.hpp"
 #include "mlir_utils.hpp"
 
-#include <string>
+#include <algorithm>
+#include <cctype>
 #include <filesystem>
 #include <iostream>
+#include <limits>
+#include <string>
 
 namespace fs = std::filesystem;
 using namespace mqss::support::quakeDialect;


### PR DESCRIPTION
## Summary
- add missing standard library headers to the info utilities implementation to cover algorithms, character checks, and numeric limits

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68caf3d172248332acbbe90dc3dcaae4