### PR TITLE
Include unistd in conversion workflow

### DIFF
--- a/AI/src/Utils/conversion_workflow.cpp
+++ b/AI/src/Utils/conversion_workflow.cpp
@@ -25,6 +25,7 @@
 #include <iostream>
 #include <string.h>
 #include <sys/wait.h>
+#include <unistd.h>
 #include <vector>
 #include <common/RuntimeMLIR.h>
 


### PR DESCRIPTION
## Summary
- include `<unistd.h>` to ensure POSIX declarations are available in the conversion workflow implementation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68caf3d202bc833298f86404c272419a