### PR TITLE
Add cmath include to environment header

### DIFF
--- a/AI/include/Environment/environment.hpp
+++ b/AI/include/Environment/environment.hpp
@@ -23,6 +23,7 @@ using llvm::dyn_cast;
 #include "Support/CodeGen/Quake.hpp"
 
 // Standard library includes
+#include <cmath>
 #include <string>
 #include <unordered_map>
 #include <filesystem>


### PR DESCRIPTION
## Summary
- include `<cmath>` alongside the other standard library headers in the environment header so that cmath declarations are available

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68caf3d4329883329079b3316907bfad