### PR TITLE
Add iostream include to passes utils

### DIFF
--- a/AI/src/Utils/passes_utils.cpp
+++ b/AI/src/Utils/passes_utils.cpp
@@ -1,3 +1,5 @@
+#include <iostream>
+
 #include "Environment/quantum_circuit_tensor.hpp"
 #include "Utils/passes_utils.hpp"
 


### PR DESCRIPTION
## Summary
- include `<iostream>` in `passes_utils.cpp` so the file has access to the standard stream definitions used within

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68caf3d50ec08332a707a1309bbab09c