### PR TITLE
Implement string constructors for A2C agents

### DIFF
--- a/AI/src/Torch/A2C/a2c_ib_fc_lsd.cpp
+++ b/AI/src/Torch/A2C/a2c_ib_fc_lsd.cpp
@@ -9,6 +9,8 @@
 #include <Utils/info_utils.hpp>
 #include <Utils/passes_utils.hpp>
 #include <Utils/progress_bar.hpp>
+#include <stdexcept>
+#include <utility>
 
 
 namespace ai_pass_selector {
@@ -45,6 +47,19 @@ A2C_IB_FC_LSD::A2C_IB_FC_LSD(
     std::cerr << "Failed to initialize A2C_IB_FC_LSD." << std::endl;
   }
 }
+
+A2C_IB_FC_LSD::A2C_IB_FC_LSD(
+    const std::string &circuit_size,
+    std::unordered_map<std::string, std::string> params)
+  : A2C_IB_FC_LSD(
+        [&circuit_size]() {
+          const auto it = CIRCUIT_SIZE_TO_CLASS.find(circuit_size);
+          if (it == CIRCUIT_SIZE_TO_CLASS.end()) {
+            throw std::runtime_error("Unsupported size: " + circuit_size);
+          }
+          return it->second;
+        }(),
+        std::move(params)) {}
 
 std::string A2C_IB_FC_LSD::agentName() const {
   std::string size_class_str;

--- a/AI/src/Torch/A2C/a2c_ib_fc_lsm.cpp
+++ b/AI/src/Torch/A2C/a2c_ib_fc_lsm.cpp
@@ -7,6 +7,8 @@
 #include <Torch/parallel_environments.hpp>
 #include <Utils/circuit_utils.hpp>
 #include <Utils/passes_utils.hpp>
+#include <stdexcept>
+#include <utility>
 
 
 namespace ai_pass_selector {
@@ -35,6 +37,20 @@ A2C_IB_FC_LSM::A2C_IB_FC_LSM(
     std::cerr << "Failed to initialize IB_FC_LSD_A2C." << std::endl;
   }
 }
+
+
+A2C_IB_FC_LSM::A2C_IB_FC_LSM(
+    const std::string &circuit_size,
+    std::unordered_map<std::string, std::string> params)
+  : A2C_IB_FC_LSM(
+        [&circuit_size]() {
+          const auto it = CIRCUIT_SIZE_TO_CLASS.find(circuit_size);
+          if (it == CIRCUIT_SIZE_TO_CLASS.end()) {
+            throw std::runtime_error("Unsupported size: " + circuit_size);
+          }
+          return it->second;
+        }(),
+        std::move(params)) {}
 
 
 std::string A2C_IB_FC_LSM::agentName() const {


### PR DESCRIPTION
## Summary
- add delegating string constructors for the A2C_IB_FC_LSD and A2C_IB_FC_LSM agents to reuse the integer-based initialization path
- include the necessary standard headers for the new delegating constructors

## Testing
- cmake -S AI -B build-ai -G Ninja *(fails: missing TensorFlow package in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbcbecf3dc8332ae2cc3b89e552c33