### PR TITLE
Preserve training parameters when constructing A2C agents

### DIFF
--- a/AI/src/Torch/training_and_run_manager.cpp
+++ b/AI/src/Torch/training_and_run_manager.cpp
@@ -32,18 +32,20 @@ std::unordered_map<std::string, std::string> train(
       if (attributes.specific_attributes[1] == "fc") {
         if (attributes.specific_attributes[2] == "lsd") {
           try {
+            auto agent_params = params;
             A2C_IB_FC_LSD agent(
-                attributes.size_class, std::move(params));
-            training_results = train_a2c(agent, dataset, std::move(params));
+                attributes.size_class, std::move(agent_params));
+            training_results = train_a2c(agent, dataset, params);
           } catch (const std::runtime_error &e) {
             std::cerr << e.what() << std::endl;
             return {};
           }
         } else if (attributes.specific_attributes[2] == "lsm") {
           try {
+            auto agent_params = params;
             A2C_IB_FC_LSM agent(
-                attributes.size_class, std::move(params));
-            training_results = train_a2c(agent, dataset, std::move(params));
+                attributes.size_class, std::move(agent_params));
+            training_results = train_a2c(agent, dataset, params);
           } catch (const std::runtime_error &e) {
             std::cerr << e.what() << std::endl;
             return {};


### PR DESCRIPTION
## Summary
- copy incoming training parameters before moving them into A2C agent constructors
- pass the copied parameters to the constructors and retain the original map for the trainer

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cbcbf3c88083329e5c7793c0b40ad3