### PR TITLE
Add validation for A2C agent names

### DIFF
--- a/AI/src/Torch/training_and_run_manager.cpp
+++ b/AI/src/Torch/training_and_run_manager.cpp
@@ -12,6 +12,7 @@
 // Stdandard library includes
 #include <unordered_map>
 #include <string>
+#include <stdexcept>
 #include <Torch/A2C/a2c_ib_fc_lsd.hpp>
 #include <Torch/A2C/a2c_ib_fc_lsm.hpp>
 #include <Torch/A2C/a2c_trainer.hpp>
@@ -28,6 +29,12 @@ std::unordered_map<std::string, std::string> train(
   switch (AgentAttributes attributes = parseAgentName(agent_name);
     attributes.agent_class) {
   case A2C:
+    if (attributes.specific_attributes.size() < 3) {
+      throw std::runtime_error(
+          "Invalid A2C agent name '" + agent_name
+          + "': expected format 'a2c-<size>-<architecture>-<network>-<variant>'"
+            " (e.g. 'a2c-small-ib-fc-lsd').");
+    }
     if (attributes.specific_attributes[0] == "ib") {
       if (attributes.specific_attributes[1] == "fc") {
         if (attributes.specific_attributes[2] == "lsd") {


### PR DESCRIPTION
## Summary
- add a guard that validates A2C agent names include all required specific attributes
- throw a descriptive runtime_error when the agent name is malformed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbcbf4dbb08332bc4acae5dab70087