### PR TITLE
Fix GAE computation for final timestep

### DIFF
--- a/AI/src/Torch/A2C/a2c_trainer.cpp
+++ b/AI/src/Torch/A2C/a2c_trainer.cpp
@@ -88,7 +88,7 @@ std::unordered_map<std::string, std::string> train_a2c(
     torch::TensorOptions options = torch::TensorOptions().device(device).dtype(
         torch::kFloat64);
     auto episode_log_probs = torch::zeros({T, B}, options);
-    auto episode_values = torch::zeros({T, B}, options);
+    auto episode_values = torch::zeros({T + 1, B}, options);
     auto episode_rewards = torch::zeros({T, B}, options);
     auto episode_entropies = torch::zeros({T, B}, options);
     auto termination_masks = torch::zeros({T, B}, options);
@@ -111,6 +111,10 @@ std::unordered_map<std::string, std::string> train_a2c(
       batched_observations
           = environments.get_batched_instruction_based_observations();
     }
+
+    episode_values[T]
+        = agent.forward(batched_observations).first.squeeze(-1).detach()
+              .to(device, options.dtype());
 
     auto [critic_loss, actor_loss] = agent.get_losses(
         episode_rewards,

--- a/AI/src/Torch/A2C/base_a2c_agent.cpp
+++ b/AI/src/Torch/A2C/base_a2c_agent.cpp
@@ -164,13 +164,18 @@ std::pair<torch::Tensor, torch::Tensor> BaseA2CAgent::get_losses(
   // based on the difference between the immediate reward obtained from a current state
   // and the estimated value of the next state.
   torch::Tensor A_gae = torch::zeros({B}, options);
-  for (int t = T - 2; t >= 0; t--) {
+  const int nr_state_values = state_values.size(0);
+  torch::Tensor bootstrap_value = torch::zeros({B}, state_values.options());
+  for (int t = T - 1; t >= 0; --t) {
+    const bool has_next_state_value = (t + 1) < nr_state_values;
+    const torch::Tensor &next_state_value
+        = has_next_state_value ? state_values[t + 1] : bootstrap_value;
 
     // In Barto & Sutton the temporal difference residual of V with discount gamma is:
     // delta_t = r_t + gamma * V(s_{t+1}) - V(s_t)
     torch::Tensor delta_t
         = rewards[t] - state_values[t]
-          + discount_factor * state_values[t + 1] * termination_masks[t];
+          + discount_factor * next_state_value * termination_masks[t];
 
     // The generalized advantage estimation defined by Schulman et al is:
     // A_gae = sum_{l=0}^{\infty} (gamma * lamda)^l * delta_{t+l}


### PR DESCRIPTION
## Summary
- extend the GAE recursion to cover the final timestep and fallback to a bootstrap value when no next state value is present
- evaluate the critic on the post-step observation so the loss computation receives the final state value sample

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cbcbf55fe08332a609f988f7ec60cd