### PR TITLE
Set default A2C optimizer defaults and add tests

### DIFF
--- a/AI/CMakeLists.txt
+++ b/AI/CMakeLists.txt
@@ -71,6 +71,13 @@ if (TORCH_SOURCES OR TORCH_HEADERS)
     target_include_directories(ai_torch PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
     target_include_directories(ai_torch PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include")
     set_property(TARGET ai_torch PROPERTY CXX_STANDARD 17)
+
+    if (BUILD_MLIR_PASSES_TESTS)
+        enable_testing()
+        add_executable(ai_base_a2c_agent_test tests/base_a2c_agent_test.cpp)
+        target_link_libraries(ai_base_a2c_agent_test PRIVATE ai_torch)
+        add_test(NAME ai-base-a2c-agent COMMAND ai_base_a2c_agent_test)
+    endif ()
 endif ()
 
 add_executable(ai_pass_selector_torch ai_pass_selector_torch.cpp)

--- a/AI/include/Torch/A2C/base_a2c_agent.hpp
+++ b/AI/include/Torch/A2C/base_a2c_agent.hpp
@@ -4,6 +4,9 @@
 // Torch includes
 #include <torch/torch.h>
 
+// Project includes
+#include "Torch/agent_utils.hpp"
+
 // Standard library includes
 #include <utility>
 #include <tuple>
@@ -16,15 +19,18 @@ namespace fs = std::filesystem;
 namespace ai_pass_selector {
     class BaseA2CAgent : public torch::nn::Module {
     protected:
+        static constexpr int DEFAULT_OPTIMIZER_TYPE = OPTIMIZER_ADAM;
+        static constexpr double DEFAULT_LEARNING_RATE = 1e-3;
+
         /// Attributes on configuration
         int size_class = 0;
         unsigned int max_qubits = 0;
         unsigned int max_instructions = 0;
         unsigned int max_depth = 0;
-        int critic_optimizer_type = 0;
-        int actor_optimizer_type = 0;
-        double critic_learning_rate = 0;
-        double actor_learning_rate = 0;
+        int critic_optimizer_type = DEFAULT_OPTIMIZER_TYPE;
+        int actor_optimizer_type = DEFAULT_OPTIMIZER_TYPE;
+        double critic_learning_rate = DEFAULT_LEARNING_RATE;
+        double actor_learning_rate = DEFAULT_LEARNING_RATE;
         unsigned int nr_parallel_environments = 0;
         torch::Device device = torch::kCPU;
 

--- a/AI/src/Torch/A2C/base_a2c_agent.cpp
+++ b/AI/src/Torch/A2C/base_a2c_agent.cpp
@@ -11,6 +11,7 @@
 #include <tuple>
 #include <cmath>
 #include <memory>
+#include <string>
 #include <Utils/circuit_utils.hpp>
 
 namespace ai_pass_selector {
@@ -36,9 +37,14 @@ void BaseA2CAgent::configure(
     std::unordered_map<std::string, std::string> params) {
   if (CIRCUIT_CLASS_TO_SPECS.find(circuit_size_class)
       == CIRCUIT_CLASS_TO_SPECS.end()) {
-    throw std::runtime_error("Unsupported size class: " + circuit_size_class);
+    throw std::runtime_error(
+        "Unsupported size class: " + std::to_string(circuit_size_class));
   }
   this->size_class = circuit_size_class;
+  this->critic_optimizer_type = DEFAULT_OPTIMIZER_TYPE;
+  this->actor_optimizer_type = DEFAULT_OPTIMIZER_TYPE;
+  this->critic_learning_rate = DEFAULT_LEARNING_RATE;
+  this->actor_learning_rate = DEFAULT_LEARNING_RATE;
   std::tie(this->max_qubits, this->max_instructions, this->max_depth)
       = CIRCUIT_CLASS_TO_SPECS.at(circuit_size_class);
   for (auto [key, value] : params) {

--- a/AI/tests/base_a2c_agent_test.cpp
+++ b/AI/tests/base_a2c_agent_test.cpp
@@ -1,0 +1,110 @@
+#include <Torch/A2C/base_a2c_agent.hpp>
+#include <Torch/agent_utils.hpp>
+#include <Utils/circuit_utils.hpp>
+
+#include <torch/torch.h>
+
+#include <cmath>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+namespace ai_pass_selector {
+namespace {
+
+class DummyA2CAgent : public BaseA2CAgent {
+  using BaseA2CAgent::BaseA2CAgent;
+
+public:
+  std::string agentName() const override { return "dummy"; }
+
+  int getCriticOptimizerType() const { return this->critic_optimizer_type; }
+  int getActorOptimizerType() const { return this->actor_optimizer_type; }
+  double getCriticLearningRate() const { return this->critic_learning_rate; }
+  double getActorLearningRate() const { return this->actor_learning_rate; }
+  torch::optim::Optimizer *getCriticOptimizer() const {
+    return this->critic_optimizer.get();
+  }
+  torch::optim::Optimizer *getActorOptimizer() const {
+    return this->actor_optimizer.get();
+  }
+};
+
+bool doublesEqual(double lhs, double rhs, double eps = 1e-12) {
+  return std::fabs(lhs - rhs) <= eps;
+}
+
+} // namespace
+} // namespace ai_pass_selector
+
+int main() {
+  using namespace ai_pass_selector;
+
+  DummyA2CAgent default_agent(TINY, {});
+  if (default_agent.getCriticOptimizerType() != OPTIMIZER_ADAM) {
+    return 1;
+  }
+  if (default_agent.getActorOptimizerType() != OPTIMIZER_ADAM) {
+    return 2;
+  }
+  if (!doublesEqual(default_agent.getCriticLearningRate(), 1e-3)) {
+    return 3;
+  }
+  if (!doublesEqual(default_agent.getActorLearningRate(), 1e-3)) {
+    return 4;
+  }
+
+  constexpr int nr_inputs = 4;
+  auto critic = torch::nn::Sequential(
+      torch::nn::Linear(torch::nn::LinearOptions(nr_inputs, 1)));
+  auto actor = torch::nn::Sequential(
+      torch::nn::Linear(torch::nn::LinearOptions(nr_inputs, 2)));
+  if (!default_agent.initialize(nr_inputs, critic, actor)) {
+    return 5;
+  }
+  if (default_agent.getCriticOptimizer() == nullptr) {
+    return 6;
+  }
+  if (default_agent.getActorOptimizer() == nullptr) {
+    return 7;
+  }
+
+  std::unordered_map<std::string, std::string> overrides = {
+      {"critic_optimizer", "sgd"},
+      {"actor_optimizer", "rmsprop"},
+      {"critic_learning_rate", "0.005"},
+      {"actor_learning_rate", "0.007"}};
+  DummyA2CAgent overridden_agent(TINY, overrides);
+  if (overridden_agent.getCriticOptimizerType() != OPTIMIZER_SGD) {
+    return 8;
+  }
+  if (overridden_agent.getActorOptimizerType() != OPTIMIZER_RMSPROP) {
+    return 9;
+  }
+  if (!doublesEqual(overridden_agent.getCriticLearningRate(), 0.005)) {
+    return 10;
+  }
+  if (!doublesEqual(overridden_agent.getActorLearningRate(), 0.007)) {
+    return 11;
+  }
+
+  auto critic_overridden = torch::nn::Sequential(
+      torch::nn::Linear(torch::nn::LinearOptions(nr_inputs, 1)));
+  auto actor_overridden = torch::nn::Sequential(
+      torch::nn::Linear(torch::nn::LinearOptions(nr_inputs, 2)));
+  if (!overridden_agent.initialize(nr_inputs, critic_overridden,
+                                   actor_overridden)) {
+    return 12;
+  }
+
+  if (dynamic_cast<torch::optim::SGD *>(
+          overridden_agent.getCriticOptimizer()) == nullptr) {
+    return 13;
+  }
+  if (dynamic_cast<torch::optim::RMSprop *>(
+          overridden_agent.getActorOptimizer()) == nullptr) {
+    return 14;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- set BaseA2CAgent default optimizer types to Adam and provide non-zero default learning rates before processing user overrides
- update the BaseA2CAgent configure path to reset optimizer configuration defaults and fix the unsupported size-class diagnostic
- add a small executable test that exercises default and user-specified optimizer settings and wire it into the AI CMake when tests are enabled

## Testing
- `cmake -S AI -B build-ai -DBUILD_MLIR_PASSES_TESTS=ON` *(fails: TensorFlow SDK not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbcbfbfcc8833296ea3e61dc515a73