### PR TITLE
Handle trainer params and add override test

### DIFF
--- a/AI/include/Torch/A2C/a2c_trainer.hpp
+++ b/AI/include/Torch/A2C/a2c_trainer.hpp
@@ -3,7 +3,25 @@
 
 #include "base_a2c_agent.hpp"
 
+#include <vector>
+#include <string>
+#include <unordered_map>
+
 namespace ai_pass_selector {
+    struct A2CTrainerConfig {
+        unsigned int nr_parallel_environments = 10;
+        unsigned int episodes = 1000;
+        unsigned int max_steps_per_episode = 20;
+        double discount_factor = 1.0;
+        double gae_hyperparameter = 0.96;
+        double entropy_coefficient = 0.01;
+        torch::Device device = torch::kCPU;
+        std::vector<std::string> applied_overrides;
+    };
+
+    A2CTrainerConfig build_a2c_trainer_config(
+        const std::unordered_map<std::string, std::string> &params);
+
     /**
      *
      * @param agent

--- a/AI/src/Torch/A2C/a2c_trainer.cpp
+++ b/AI/src/Torch/A2C/a2c_trainer.cpp
@@ -7,10 +7,58 @@
 #include <Utils/info_utils.hpp>
 #include <Utils/progress_bar.hpp>
 
+#include <algorithm>
+#include <cctype>
+#include <iostream>
+#include <sstream>
+
 using namespace mqss::support::quakeDialect;
 namespace fs = std::filesystem;
 
 namespace ai_pass_selector {
+A2CTrainerConfig build_a2c_trainer_config(
+    const std::unordered_map<std::string, std::string> &params) {
+  A2CTrainerConfig config;
+  for (const auto &[key, value] : params) {
+    if (key == "nr_parallel_environments") {
+      config.nr_parallel_environments = std::stoul(value);
+      config.applied_overrides.push_back(key + "=" + value);
+    } else if (key == "episodes") {
+      config.episodes = std::stoul(value);
+      config.applied_overrides.push_back(key + "=" + value);
+    } else if (key == "max_steps_per_episode") {
+      config.max_steps_per_episode = std::stoul(value);
+      config.applied_overrides.push_back(key + "=" + value);
+    } else if (key == "discount_factor") {
+      config.discount_factor = std::stod(value);
+      config.applied_overrides.push_back(key + "=" + value);
+    } else if (key == "gae_hyperparameter") {
+      config.gae_hyperparameter = std::stod(value);
+      config.applied_overrides.push_back(key + "=" + value);
+    } else if (key == "entropy_coefficient") {
+      config.entropy_coefficient = std::stod(value);
+      config.applied_overrides.push_back(key + "=" + value);
+    } else if (key == "device") {
+      std::string value_lower = value;
+      std::transform(
+          value_lower.begin(), value_lower.end(), value_lower.begin(),
+          [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+      if (value_lower == "cpu") {
+        config.device = torch::kCPU;
+        config.applied_overrides.push_back("device=cpu");
+      } else if (value_lower == "cuda" || value_lower == "gpu") {
+        if (torch::cuda::is_available()) {
+          config.device = torch::kCUDA;
+          config.applied_overrides.push_back("device=cuda");
+        } else {
+          config.applied_overrides.push_back("device=" + value_lower + " (unavailable)");
+        }
+      }
+    }
+  }
+  return config;
+}
+
 std::unordered_map<std::string, std::string> train_a2c(
     BaseA2CAgent &agent,
     const std::string &dataset,
@@ -19,33 +67,22 @@ std::unordered_map<std::string, std::string> train_a2c(
   unsigned int max_instructions = agent.getMaxInstructions();
   unsigned int max_depth = agent.getMaxDepth();
 
-  // Default values
-  unsigned int nr_parallel_environments = 10;
-  unsigned int episodes = 1000;
-  unsigned int max_steps_per_episode = 20;
-  double discount_factor = 1.0;
-  double gae_hyperparameter = 0.96;
-  double entropy_coefficient = 0.01;
-  torch::Device device = torch::kCPU;
-  for (auto [key, value] : params) {
-    if (key == "nr_parallel_environments") {
-      nr_parallel_environments = std::stoul(value);
-    } else if (key == "episodes") {
-      episodes = std::stoul(value);
-    } else if (key == "max_steps_per_episode") {
-      max_steps_per_episode = std::stoul(value);
-    } else if (key == "discount_factor") {
-      discount_factor = std::stod(value);
-    } else if (key == "gae_hyperparameter") {
-      gae_hyperparameter = std::stod(value);
-    } else if (key == "entropy_coefficient") {
-      entropy_coefficient = std::stod(value);
-    } else if (key == "device"
-               && (value == "cuda" || value == "gpu")
-               && torch::cuda::is_available()) {
-      device = torch::kCUDA;
+  A2CTrainerConfig config = build_a2c_trainer_config(params);
+  if (!config.applied_overrides.empty()) {
+    std::ostringstream overrides_stream;
+    overrides_stream << "train_a2c overrides:";
+    for (const auto &override_entry : config.applied_overrides) {
+      overrides_stream << ' ' << override_entry;
     }
+    std::cout << overrides_stream.str() << std::endl;
   }
+  unsigned int nr_parallel_environments = config.nr_parallel_environments;
+  unsigned int episodes = config.episodes;
+  unsigned int max_steps_per_episode = config.max_steps_per_episode;
+  double discount_factor = config.discount_factor;
+  double gae_hyperparameter = config.gae_hyperparameter;
+  double entropy_coefficient = config.entropy_coefficient;
+  torch::Device device = config.device;
 
   if (agent.getNrInputValues() <= 0 || nr_parallel_environments <= 0) {
     std::cerr << "No agent to train." << std::endl;

--- a/AI/src/Torch/training_and_run_manager.cpp
+++ b/AI/src/Torch/training_and_run_manager.cpp
@@ -32,8 +32,9 @@ std::unordered_map<std::string, std::string> train(
       if (attributes.specific_attributes[1] == "fc") {
         if (attributes.specific_attributes[2] == "lsd") {
           try {
+            auto agent_params = params;
             A2C_IB_FC_LSD agent(
-                attributes.size_class, std::move(params));
+                attributes.size_class, std::move(agent_params));
             training_results = train_a2c(agent, dataset, std::move(params));
           } catch (const std::runtime_error &e) {
             std::cerr << e.what() << std::endl;
@@ -41,8 +42,9 @@ std::unordered_map<std::string, std::string> train(
           }
         } else if (attributes.specific_attributes[2] == "lsm") {
           try {
+            auto agent_params = params;
             A2C_IB_FC_LSM agent(
-                attributes.size_class, std::move(params));
+                attributes.size_class, std::move(agent_params));
             training_results = train_a2c(agent, dataset, std::move(params));
           } catch (const std::runtime_error &e) {
             std::cerr << e.what() << std::endl;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -150,3 +150,13 @@ set(TEST_OUTPUT_DIR $<TARGET_FILE_DIR:test-mqss-passes>/qasm)
 add_custom_target(
         copy-qasm-test ALL COMMAND ${CMAKE_COMMAND} -E copy_directory
         ${CMAKE_SOURCE_DIR}/tests/qasm ${TEST_OUTPUT_DIR})
+
+if (TARGET ai_torch)
+    add_executable(test-a2c-trainer-config testA2CTrainerConfig.cpp)
+    target_link_libraries(test-a2c-trainer-config PRIVATE ${GTEST_LIBRARIES} ai_torch)
+    target_include_directories(
+            test-a2c-trainer-config
+            PRIVATE ${CMAKE_SOURCE_DIR}/AI/include
+            ${CMAKE_SOURCE_DIR}/include)
+    add_test(NAME Test-a2c-trainer-config COMMAND test-a2c-trainer-config)
+endif ()

--- a/tests/testA2CTrainerConfig.cpp
+++ b/tests/testA2CTrainerConfig.cpp
@@ -1,0 +1,68 @@
+#include <gtest/gtest.h>
+
+#include "Torch/A2C/a2c_trainer.hpp"
+#include "Torch/A2C/base_a2c_agent.hpp"
+#include "Utils/circuit_utils.hpp"
+
+#include <algorithm>
+#include <unordered_map>
+
+using namespace ai_pass_selector;
+
+TEST(A2CTrainerConfigTest, AppliesOverrides) {
+  std::unordered_map<std::string, std::string> params = {
+      {"nr_parallel_environments", "7"},
+      {"episodes", "3"},
+      {"max_steps_per_episode", "11"},
+      {"discount_factor", "0.5"},
+      {"gae_hyperparameter", "0.77"},
+      {"entropy_coefficient", "0.02"},
+      {"device", "cpu"},
+  };
+
+  const auto config = build_a2c_trainer_config(params);
+
+  EXPECT_EQ(config.nr_parallel_environments, 7u);
+  EXPECT_EQ(config.episodes, 3u);
+  EXPECT_EQ(config.max_steps_per_episode, 11u);
+  EXPECT_DOUBLE_EQ(config.discount_factor, 0.5);
+  EXPECT_DOUBLE_EQ(config.gae_hyperparameter, 0.77);
+  EXPECT_DOUBLE_EQ(config.entropy_coefficient, 0.02);
+  EXPECT_EQ(config.device.type(), torch::kCPU);
+
+  for (const auto &expected_override : {
+           std::string("nr_parallel_environments=7"),
+           std::string("episodes=3"),
+           std::string("max_steps_per_episode=11"),
+           std::string("discount_factor=0.5"),
+           std::string("gae_hyperparameter=0.77"),
+           std::string("entropy_coefficient=0.02"),
+           std::string("device=cpu"),
+       }) {
+    EXPECT_NE(
+        std::find(
+            config.applied_overrides.begin(),
+            config.applied_overrides.end(),
+            expected_override),
+        config.applied_overrides.end())
+        << "Missing override entry: " << expected_override;
+  }
+}
+
+namespace {
+class DummyAgent : public BaseA2CAgent {
+public:
+  DummyAgent() : BaseA2CAgent(TINY, {}) { nr_input_values = 1; }
+  std::string agentName() const override { return "dummy"; }
+};
+} // namespace
+
+TEST(A2CTrainerConfigTest, OverridesAffectTrainingFlow) {
+  DummyAgent agent;
+  std::unordered_map<std::string, std::string> params = {
+      {"nr_parallel_environments", "0"},
+  };
+
+  const auto results = train_a2c(agent, "", params);
+  EXPECT_TRUE(results.empty());
+}


### PR DESCRIPTION
## Summary
- avoid double moving trainer parameters when constructing the agent
- centralize parsing of A2C trainer overrides and log the applied overrides
- add a unit test that ensures overrides are honored and hook it into the test suite

## Testing
- cmake -S . -B build -DBUILD_MLIR_PASSES_AI=ON

------
https://chatgpt.com/codex/tasks/task_e_68cbcbfca2508332a65ecbdbf9898eb5