### PR TITLE
Fix size class diagnostic construction

### DIFF
--- a/AI/src/Torch/A2C/base_a2c_agent.cpp
+++ b/AI/src/Torch/A2C/base_a2c_agent.cpp
@@ -36,7 +36,8 @@ void BaseA2CAgent::configure(
     std::unordered_map<std::string, std::string> params) {
   if (CIRCUIT_CLASS_TO_SPECS.find(circuit_size_class)
       == CIRCUIT_CLASS_TO_SPECS.end()) {
-    throw std::runtime_error("Unsupported size class: " + circuit_size_class);
+    throw std::runtime_error(
+        "Unsupported size class: " + std::to_string(circuit_size_class));
   }
   this->size_class = circuit_size_class;
   std::tie(this->max_qubits, this->max_instructions, this->max_depth)


### PR DESCRIPTION
## Summary
- use std::to_string when building the unsupported size class diagnostic in BaseA2CAgent::configure

## Testing
- cmake -S . -B build *(fails: missing MLIR package in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbcbfec3888332bc8e678c601c2ef8