### PR TITLE
Fix A2C training parameter handling

### DIFF
--- a/AI/src/Torch/training_and_run_manager.cpp
+++ b/AI/src/Torch/training_and_run_manager.cpp
@@ -32,18 +32,20 @@ std::unordered_map<std::string, std::string> train(
       if (attributes.specific_attributes[1] == "fc") {
         if (attributes.specific_attributes[2] == "lsd") {
           try {
+            auto agent_params = params;
             A2C_IB_FC_LSD agent(
-                attributes.size_class, std::move(params));
-            training_results = train_a2c(agent, dataset, std::move(params));
+                attributes.size_class, std::move(agent_params));
+            training_results = train_a2c(agent, dataset, params);
           } catch (const std::runtime_error &e) {
             std::cerr << e.what() << std::endl;
             return {};
           }
         } else if (attributes.specific_attributes[2] == "lsm") {
           try {
+            auto agent_params = params;
             A2C_IB_FC_LSM agent(
-                attributes.size_class, std::move(params));
-            training_results = train_a2c(agent, dataset, std::move(params));
+                attributes.size_class, std::move(agent_params));
+            training_results = train_a2c(agent, dataset, params);
           } catch (const std::runtime_error &e) {
             std::cerr << e.what() << std::endl;
             return {};


### PR DESCRIPTION
## Summary
- ensure A2C agents receive a copied parameter map so the original remains populated
- pass the original parameter map to train_a2c for both LSD and LSM A2C variants

## Testing
- ./build.sh *(fails: repository clone blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbcbff56c8833294ac196e2386073d