### PR TITLE
Add guard for missing agent modifiers in training manager

### DIFF
--- a/AI/src/Torch/training_and_run_manager.cpp
+++ b/AI/src/Torch/training_and_run_manager.cpp
@@ -28,6 +28,13 @@ std::unordered_map<std::string, std::string> train(
   switch (AgentAttributes attributes = parseAgentName(agent_name);
     attributes.agent_class) {
   case A2C:
+    if (attributes.specific_attributes.size() < 3) {
+      std::cerr
+          << "Agent '" << agent_name
+          << "' is missing required modifiers (expected at least three)."
+          << std::endl;
+      return {};
+    }
     if (attributes.specific_attributes[0] == "ib") {
       if (attributes.specific_attributes[1] == "fc") {
         if (attributes.specific_attributes[2] == "lsd") {


### PR DESCRIPTION
## Summary
- add a guard before accessing agent-specific modifiers in the training manager
- emit a descriptive error when required modifiers are missing so training exits early

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cbcbffc600833280255c6f84d0f89a