### PR TITLE
Set default optimizers for A2C agents

### DIFF
--- a/AI/ai_pass_selector_torch.cpp
+++ b/AI/ai_pass_selector_torch.cpp
@@ -23,7 +23,11 @@ void print_help() {
       "  -o, --output <file_path>      Circuit file path to output the optimized circuit if using the passes.\n"
       "  -i, --info                    Print info of provided arguments.\n"
       "Other parameters:\n"
-      "  <key>=<value>                 Parameters for agent/environment/training, will be loaded with default values if nor provided.\n\n";
+      "  <key>=<value>                 Parameters for agent/environment/training, will be loaded with default values if not provided.\n"
+      "    critic_optimizer=adam       Optimizer for the critic network (default: adam).\n"
+      "    actor_optimizer=adam        Optimizer for the actor network (default: adam).\n"
+      "    critic_learning_rate=0.001  Learning rate for the critic optimizer (default: 0.001).\n"
+      "    actor_learning_rate=0.0001  Learning rate for the actor optimizer (default: 0.0001).\n\n";
 }
 
 int main(int argc, char **argv) {

--- a/AI/src/Torch/A2C/base_a2c_agent.cpp
+++ b/AI/src/Torch/A2C/base_a2c_agent.cpp
@@ -41,6 +41,13 @@ void BaseA2CAgent::configure(
   this->size_class = circuit_size_class;
   std::tie(this->max_qubits, this->max_instructions, this->max_depth)
       = CIRCUIT_CLASS_TO_SPECS.at(circuit_size_class);
+
+  // Sensible defaults that can be overridden by CLI parameters.
+  this->critic_optimizer_type = OPTIMIZER_ADAM;
+  this->actor_optimizer_type = OPTIMIZER_ADAM;
+  this->critic_learning_rate = 1e-3;
+  this->actor_learning_rate = 1e-4;
+
   for (auto [key, value] : params) {
     if (key == "critic_optimizer") {
       if (OPTIMIZER_NAME_TO_TYPE.find(value) == OPTIMIZER_NAME_TO_TYPE.end()) {


### PR DESCRIPTION
## Summary
- set default Adam optimizers and learning rates during A2C agent configuration so an empty parameter map works
- document the CLI defaults for optimizer choices and learning rates in the Torch helper

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68cbcc0083cc833283246a3ab0413d25