### PR TITLE
Handle terminated environments during A2C training

### DIFF
--- a/AI/include/Torch/parallel_environments.hpp
+++ b/AI/include/Torch/parallel_environments.hpp
@@ -3,6 +3,7 @@
 #include <Environment/environment.hpp>
 
 #include <torch/torch.h>
+#include <cstdint>
 
 namespace ai_pass_selector {
     class ParallelEnvironments {
@@ -77,6 +78,11 @@ namespace ai_pass_selector {
          */
         std::tuple<std::vector<double>, std::vector<bool> >
         step(const std::vector<unsigned int> &actions);
+
+        std::tuple<std::vector<double>, std::vector<bool> >
+        step(
+            const std::vector<unsigned int> &actions,
+            const std::vector<uint8_t> &active_mask);
     };
 } // namespace ai_pass_selector
 

--- a/AI/src/Torch/A2C/a2c_trainer.cpp
+++ b/AI/src/Torch/A2C/a2c_trainer.cpp
@@ -1,7 +1,9 @@
 #include "Torch/A2C/a2c_trainer.hpp"
 
 #include <Quake.hpp>
+#include <cstdint>
 #include <filesystem>
+#include <iostream>
 #include <mlir_utils.hpp>
 #include <Torch/parallel_environments.hpp>
 #include <Utils/info_utils.hpp>
@@ -78,9 +80,11 @@ std::unordered_map<std::string, std::string> train_a2c(
   std::vector<double> actor_losses;
 
   for (unsigned int episode_nr = 1; episode_nr <= episodes; episode_nr++) {
+    std::vector<fs::path> environment_circuits(nr_parallel_environments);
     for (unsigned int i = 0; i < nr_parallel_environments; i++) {
       fs::path random_dataset_entry
           = filtered_dataset_files[random_int(0, dataset_size)];
+      environment_circuits[i] = random_dataset_entry;
       environments.register_quantum_circuit(i, random_dataset_entry);
     }
     int64_t T = max_steps_per_episode;
@@ -95,21 +99,58 @@ std::unordered_map<std::string, std::string> train_a2c(
 
     torch::Tensor batched_observations =
         environments.get_batched_instruction_based_observations();
+    std::vector<uint8_t> active_mask(B, 1);
+    unsigned int active_envs = B;
     for (unsigned int update_step = 0;
          update_step < max_steps_per_episode;
          update_step++) {
+      if (active_envs == 0) {
+        break;
+      }
+      std::vector<uint8_t> step_mask = active_mask;
       auto [actions, log_action_probs, state_values, step_entropy]
           = agent.select_action(batched_observations);
-      auto [rewards, terminates] = environments.step(actions);
+      for (int64_t b = 0; b < B; ++b) {
+        if (step_mask[b]) {
+          continue;
+        }
+        actions[b] = 0;
+        const int64_t index = b;
+        log_action_probs.index_put_({index}, 0.0);
+        state_values.index_put_({index}, 0.0);
+        step_entropy.index_put_({index}, 0.0);
+      }
+      auto [rewards, terminates] = environments.step(actions, step_mask);
       episode_log_probs[update_step] = log_action_probs;
       episode_values[update_step] = state_values;
       episode_entropies[update_step] = step_entropy;
-      for (unsigned int b = 0; b < B; b++) {
-        episode_rewards[update_step][b] = rewards[b];
-        termination_masks[update_step][b] = terminates[b] ? 0.0 : 1.0;
+      for (int64_t b = 0; b < B; b++) {
+        episode_rewards[update_step][b] = step_mask[b] ? rewards[b] : 0.0;
+        termination_masks[update_step][b] = (step_mask[b] && !terminates[b]) ? 1.0 : 0.0;
+        if (step_mask[b] && terminates[b]) {
+          active_mask[b] = 0;
+          if (active_envs > 0) {
+            active_envs--;
+          }
+          if (!environment_circuits[b].empty()
+              && !environments.register_quantum_circuit(
+                  static_cast<unsigned int>(b),
+                  environment_circuits[b])) {
+            std::cerr << "Failed to reset circuit for environment " << b
+                      << std::endl;
+          }
+        }
+      }
+      if (active_envs == 0) {
+        break;
       }
       batched_observations
           = environments.get_batched_instruction_based_observations();
+      for (int64_t b = 0; b < B; ++b) {
+        if (!active_mask[b]) {
+          batched_observations.select(0, b).zero_();
+        }
+      }
     }
 
     auto [critic_loss, actor_loss] = agent.get_losses(

--- a/AI/src/Torch/parallel_environments.cpp
+++ b/AI/src/Torch/parallel_environments.cpp
@@ -47,24 +47,40 @@ unsigned int ParallelEnvironments::size() const {
 
 std::tuple<std::vector<double>, std::vector<bool> >
 ParallelEnvironments::step(const std::vector<unsigned int> &actions) {
+  std::vector<uint8_t> active_mask(nr_environments, 1);
+  return step(actions, active_mask);
+}
+
+std::tuple<std::vector<double>, std::vector<bool> >
+ParallelEnvironments::step(
+    const std::vector<unsigned int> &actions,
+    const std::vector<uint8_t> &active_mask) {
   if (actions.size() != nr_environments) {
     throw std::runtime_error("actions.size() != nr_environments");
   }
-  std::vector<std::future<std::tuple<double, bool> > > futures;
-  futures.reserve(nr_environments);
-  for (size_t i = 0; i < nr_environments; ++i) {
-    futures.emplace_back(std::async(std::launch::async, [&, i] {
-      return environments[i].step(actions[i]);
-    }));
+  if (active_mask.size() != nr_environments) {
+    throw std::runtime_error("active_mask.size() != nr_environments");
   }
-  std::vector<double> rewards;
-  std::vector<bool> terminates;
-  rewards.reserve(nr_environments);
-  terminates.reserve(nr_environments);
-  for (auto &future : futures) {
-    auto result = future.get();
-    rewards.push_back(std::get<0>(result));
-    terminates.push_back(std::get<1>(result));
+  std::vector<std::future<std::tuple<double, bool> > > futures(nr_environments);
+  std::vector<uint8_t> should_wait(nr_environments, 0);
+  for (size_t i = 0; i < nr_environments; ++i) {
+    if (!active_mask[i]) {
+      continue;
+    }
+    should_wait[i] = 1;
+    futures[i] = std::async(std::launch::async, [&, i] {
+      return environments[i].step(actions[i]);
+    });
+  }
+  std::vector<double> rewards(nr_environments, 0.0);
+  std::vector<bool> terminates(nr_environments, true);
+  for (size_t i = 0; i < nr_environments; ++i) {
+    if (!should_wait[i]) {
+      continue;
+    }
+    auto result = futures[i].get();
+    rewards[i] = std::get<0>(result);
+    terminates[i] = std::get<1>(result);
   }
   return {std::move(rewards), std::move(terminates)};
 }


### PR DESCRIPTION
## Summary
- extend the parallel environments wrapper so callers can mask out inactive slots when stepping
- update the A2C trainer to track terminated environments, reset their circuits, and avoid feeding them back into the agent

## Testing
- cmake -S AI -B build-ai *(fails: TensorFlow SDK not present in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbcc012ec0833299985aab695f8a25