### PR TITLE
Fix GAE loop to include final timestep

### DIFF
--- a/AI/src/Torch/A2C/base_a2c_agent.cpp
+++ b/AI/src/Torch/A2C/base_a2c_agent.cpp
@@ -164,13 +164,16 @@ std::pair<torch::Tensor, torch::Tensor> BaseA2CAgent::get_losses(
   // based on the difference between the immediate reward obtained from a current state
   // and the estimated value of the next state.
   torch::Tensor A_gae = torch::zeros({B}, options);
-  for (int t = T - 2; t >= 0; t--) {
+  const torch::Tensor zero_state_value = torch::zeros({B}, state_values.options());
+  for (int t = T - 1; t >= 0; --t) {
+    const torch::Tensor next_state_value
+        = (t + 1 < state_values.size(0)) ? state_values[t + 1] : zero_state_value;
 
     // In Barto & Sutton the temporal difference residual of V with discount gamma is:
     // delta_t = r_t + gamma * V(s_{t+1}) - V(s_t)
     torch::Tensor delta_t
         = rewards[t] - state_values[t]
-          + discount_factor * state_values[t + 1] * termination_masks[t];
+          + discount_factor * next_state_value * termination_masks[t];
 
     // The generalized advantage estimation defined by Schulman et al is:
     // A_gae = sum_{l=0}^{\infty} (gamma * lamda)^l * delta_{t+l}


### PR DESCRIPTION
## Summary
- update the GAE loop to iterate through the final timestep and provide a bootstrap value when the next state estimate is unavailable
- ensure every timestep receives an advantage estimate before computing actor and critic losses

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cbcbebfe788332b19fbefc47b54c93