### PR TITLE
Load AI defaults from YAML configuration

### DIFF
--- a/AI/CMakeLists.txt
+++ b/AI/CMakeLists.txt
@@ -10,6 +10,7 @@ list(APPEND CMAKE_PREFIX_PATH
 # Find each SDK, but we will not mix them in a single target
 find_package(TensorFlow CONFIG REQUIRED)
 find_package(Torch REQUIRED)
+find_package(yaml-cpp REQUIRED)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -74,7 +75,7 @@ if (TORCH_SOURCES OR TORCH_HEADERS)
 endif ()
 
 add_executable(ai_pass_selector_torch ai_pass_selector_torch.cpp)
-target_link_libraries(ai_pass_selector_torch PRIVATE ai_torch)
+target_link_libraries(ai_pass_selector_torch PRIVATE ai_torch yaml-cpp)
 
 # ---------------- TensorFlow-only targets ----------------
 file(GLOB_RECURSE TENSORFLOW_HEADERS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/include/Tensorflow/*.hpp")

--- a/AI/ai_pass_selector_torch.cpp
+++ b/AI/ai_pass_selector_torch.cpp
@@ -2,10 +2,14 @@
 #include "Utils/info_utils.hpp"
 
 #include <torch/torch.h>
+#include <cstdlib>
 #include <filesystem>
 #include <iostream>
 #include <string>
+#include <system_error>
+#include <unordered_map>
 #include <vector>
+#include <yaml-cpp/yaml.h>
 #include <Torch/agent_utils.hpp>
 #include <Torch/training_and_run_manager.hpp>
 
@@ -13,6 +17,9 @@ using namespace ai_pass_selector;
 namespace fs = std::filesystem;
 
 /// Default values for agent/environment/training parameters.
+std::unordered_map<std::string, std::string> load_params_from_yaml(
+    const std::string &path,
+    std::unordered_map<std::string, std::string> defaults = {});
 std::unordered_map<std::string, std::string> load_default_params();
 
 void print_help() {
@@ -122,8 +129,34 @@ int main(int argc, char **argv) {
 }
 
 
+std::unordered_map<std::string, std::string> load_params_from_yaml(
+    const std::string &path,
+    std::unordered_map<std::string, std::string> defaults) {
+  try {
+    YAML::Node cfg = YAML::LoadFile(path);
+    if (!cfg || !cfg.IsMap()) {
+      return defaults;
+    }
+
+    for (const auto &it : cfg) {
+      const std::string key = it.first.as<std::string>();
+      if (it.second.IsScalar()) {
+        defaults[key] = it.second.as<std::string>();
+      }
+    }
+  } catch (const YAML::BadFile &) {
+    return defaults;
+  } catch (const std::exception &ex) {
+    std::cerr << "Failed to parse params YAML '" << path
+              << "': " << ex.what() << std::endl;
+    return defaults;
+  }
+
+  return defaults;
+}
+
 std::unordered_map<std::string, std::string> load_default_params() {
-  return {
+  std::unordered_map<std::string, std::string> defaults = {
       {"agent", ""},
       {"dataset", ""},
       {"circuit", ""},
@@ -141,4 +174,23 @@ std::unordered_map<std::string, std::string> load_default_params() {
       {"actor_learning_rate", "0.001"},
       {"print_param_info", ""}
   };
+
+  const char *env_path = std::getenv("MQSS_AI_DEFAULT_PARAMS");
+  const fs::path source_dir = fs::path(__FILE__).parent_path();
+  const std::vector<fs::path> candidate_paths = {
+      source_dir / "default_params.yaml",
+      env_path == nullptr ? fs::path{} : fs::path(env_path)};
+
+  for (const auto &candidate : candidate_paths) {
+    if (candidate.empty()) {
+      continue;
+    }
+
+    std::error_code ec;
+    if (fs::exists(candidate, ec) && !ec && fs::is_regular_file(candidate, ec)) {
+      defaults = load_params_from_yaml(candidate.string(), std::move(defaults));
+    }
+  }
+
+  return defaults;
 }

--- a/AI/default_params.yaml
+++ b/AI/default_params.yaml
@@ -1,0 +1,16 @@
+agent: ""
+dataset: ""
+circuit: ""
+output: ""
+nr_parallel_environments: 1
+episodes: 1000
+max_steps_per_episode: 5
+discount_factor: 1.0
+gae_hyperparameter: 0.96
+entropy_coefficient: 0.01
+device: cpu
+critic_optimizer: adam
+actor_optimizer: adam
+critic_learning_rate: 0.005
+actor_learning_rate: 0.001
+print_param_info: ""


### PR DESCRIPTION
## Summary
- load Torch pass selector defaults through a YAML helper that stringifies scalar values
- ship a default_params.yaml file and allow overriding via the MQSS_AI_DEFAULT_PARAMS environment variable
- link yaml-cpp so the Torch selector can parse configuration files at runtime

## Testing
- not run (Torch/TensorFlow/yaml-cpp dependencies are unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cbfc1a5a408332afea6e4ee7a46db8