### PR TITLE
Fix single-qubit cancellation guards and add tests

### DIFF
--- a/lib/Passes/Cancellations/XXToId.cpp
+++ b/lib/Passes/Cancellations/XXToId.cpp
@@ -31,7 +31,7 @@ public:
     kernel.walk([&](Operation *op) {
       auto xOp1 = dyn_cast_or_null<quake::XOp>(*op);
       if (!xOp1
-          || !xOp1.isAdj()
+          || xOp1.isAdj()
           || xOp1.getTargets().size() != 1
           || !xOp1.getControls().empty()) {
         return;

--- a/lib/Passes/Cancellations/YYToId.cpp
+++ b/lib/Passes/Cancellations/YYToId.cpp
@@ -30,7 +30,7 @@ public:
     kernel.walk([&](Operation *op) {
       auto yOp1 = dyn_cast_or_null<quake::YOp>(*op);
       if (!yOp1
-          || !yOp1.isAdj()
+          || yOp1.isAdj()
           || yOp1.getTargets().size() != 1
           || !yOp1.getControls().empty()) {
         return;

--- a/lib/Passes/Cancellations/ZZToId.cpp
+++ b/lib/Passes/Cancellations/ZZToId.cpp
@@ -31,7 +31,7 @@ public:
     kernel.walk([&](Operation *op) {
       auto zOp1 = dyn_cast_or_null<quake::ZOp>(*op);
       if (!zOp1
-          || !zOp1.isAdj()
+          || zOp1.isAdj()
           || zOp1.getTargets().size() != 1
           || !zOp1.getControls().empty()) {
         return;

--- a/tests/golden-cases/XXToIdPass.qke
+++ b/tests/golden-cases/XXToIdPass.qke
@@ -1,0 +1,13 @@
+module {
+  func.func @__nvqpp__mlirgen__testXXToId() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+    %0 = quake.alloca !quake.veq<1>
+    %1 = quake.extract_ref %0[0] : (!quake.veq<1>) -> !quake.ref
+    quake.x<adj> %1 : (!quake.ref) -> ()
+    quake.x %1 : (!quake.ref) -> ()
+    quake.x<adj> %1 : (!quake.ref) -> ()
+    quake.x %1 : (!quake.ref) -> ()
+    %measOut = quake.mz %0 : (!quake.veq<1>) -> !cc.stdvec<!quake.measure>
+    return
+  }
+}
+

--- a/tests/golden-cases/YYToIdPass.qke
+++ b/tests/golden-cases/YYToIdPass.qke
@@ -1,0 +1,13 @@
+module {
+  func.func @__nvqpp__mlirgen__testYYToId() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+    %0 = quake.alloca !quake.veq<1>
+    %1 = quake.extract_ref %0[0] : (!quake.veq<1>) -> !quake.ref
+    quake.y<adj> %1 : (!quake.ref) -> ()
+    quake.y %1 : (!quake.ref) -> ()
+    quake.y<adj> %1 : (!quake.ref) -> ()
+    quake.y %1 : (!quake.ref) -> ()
+    %measOut = quake.mz %0 : (!quake.veq<1>) -> !cc.stdvec<!quake.measure>
+    return
+  }
+}
+

--- a/tests/golden-cases/ZZToIdPass.qke
+++ b/tests/golden-cases/ZZToIdPass.qke
@@ -1,0 +1,13 @@
+module {
+  func.func @__nvqpp__mlirgen__testZZToId() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+    %0 = quake.alloca !quake.veq<1>
+    %1 = quake.extract_ref %0[0] : (!quake.veq<1>) -> !quake.ref
+    quake.z<adj> %1 : (!quake.ref) -> ()
+    quake.z %1 : (!quake.ref) -> ()
+    quake.z<adj> %1 : (!quake.ref) -> ()
+    quake.z %1 : (!quake.ref) -> ()
+    %measOut = quake.mz %0 : (!quake.veq<1>) -> !cc.stdvec<!quake.measure>
+    return
+  }
+}
+

--- a/tests/quake/XXToIdPass.qke
+++ b/tests/quake/XXToIdPass.qke
@@ -1,0 +1,13 @@
+func.func @__nvqpp__mlirgen__testXXToId() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+  %0 = quake.alloca !quake.veq<1>
+  %1 = quake.extract_ref %0[0] : (!quake.veq<1>) -> !quake.ref
+  quake.x %1 : (!quake.ref) -> ()
+  quake.x %1 : (!quake.ref) -> ()
+  quake.x<adj> %1 : (!quake.ref) -> ()
+  quake.x %1 : (!quake.ref) -> ()
+  quake.x<adj> %1 : (!quake.ref) -> ()
+  quake.x %1 : (!quake.ref) -> ()
+  %measOut = quake.mz %0 : (!quake.veq<1>) -> !cc.stdvec<!quake.measure>
+  return
+}
+

--- a/tests/quake/YYToIdPass.qke
+++ b/tests/quake/YYToIdPass.qke
@@ -1,0 +1,13 @@
+func.func @__nvqpp__mlirgen__testYYToId() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+  %0 = quake.alloca !quake.veq<1>
+  %1 = quake.extract_ref %0[0] : (!quake.veq<1>) -> !quake.ref
+  quake.y %1 : (!quake.ref) -> ()
+  quake.y %1 : (!quake.ref) -> ()
+  quake.y<adj> %1 : (!quake.ref) -> ()
+  quake.y %1 : (!quake.ref) -> ()
+  quake.y<adj> %1 : (!quake.ref) -> ()
+  quake.y %1 : (!quake.ref) -> ()
+  %measOut = quake.mz %0 : (!quake.veq<1>) -> !cc.stdvec<!quake.measure>
+  return
+}
+

--- a/tests/quake/ZZToIdPass.qke
+++ b/tests/quake/ZZToIdPass.qke
@@ -1,0 +1,13 @@
+func.func @__nvqpp__mlirgen__testZZToId() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+  %0 = quake.alloca !quake.veq<1>
+  %1 = quake.extract_ref %0[0] : (!quake.veq<1>) -> !quake.ref
+  quake.z %1 : (!quake.ref) -> ()
+  quake.z %1 : (!quake.ref) -> ()
+  quake.z<adj> %1 : (!quake.ref) -> ()
+  quake.z %1 : (!quake.ref) -> ()
+  quake.z<adj> %1 : (!quake.ref) -> ()
+  quake.z %1 : (!quake.ref) -> ()
+  %measOut = quake.mz %0 : (!quake.veq<1>) -> !cc.stdvec<!quake.measure>
+  return
+}
+

--- a/tests/testMQSSPasses.cpp
+++ b/tests/testMQSSPasses.cpp
@@ -447,6 +447,18 @@ INSTANTIATE_TEST_SUITE_P(
         "./golden-cases/ZeroRzToIdPass.qke",
         []() { return mqss::opt::createZeroRzToIdPass(); }, false),
       std::make_tuple(
+        "XXToIdPass", "./quake/XXToIdPass.qke",
+        "./golden-cases/XXToIdPass.qke",
+        []() { return mqss::opt::createXXToIdPass(); }, false),
+      std::make_tuple(
+        "YYToIdPass", "./quake/YYToIdPass.qke",
+        "./golden-cases/YYToIdPass.qke",
+        []() { return mqss::opt::createYYToIdPass(); }, false),
+      std::make_tuple(
+        "ZZToIdPass", "./quake/ZZToIdPass.qke",
+        "./golden-cases/ZZToIdPass.qke",
+        []() { return mqss::opt::createZZToIdPass(); }, false),
+      std::make_tuple(
         "SdgZToSPass", "./quake/SAdjToSPass.qke",
         "./golden-cases/SAdjToSPass.qke",
         []() { return mqss::opt::createSdgZToSPass(); }, false),


### PR DESCRIPTION
## Summary
- update the XX/YY/ZZ cancellation passes so they only skip when the leading gate is adjoint while still requiring a non-adjoint partner
- add quake and golden fixtures plus test harness wiring to cover cancellation of plain X/Y/Z pairs and preservation of adjoint combinations

## Testing
- cmake -S . -B build -G Ninja *(fails: missing MLIR package configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68cc13a785c08332a8cf9e65d8f0a6cc