### PR TITLE
Handle symbolic parameters in zero rotation cancellations

### DIFF
--- a/lib/Passes/Cancellations/ZeroRxToId.cpp
+++ b/lib/Passes/Cancellations/ZeroRxToId.cpp
@@ -44,7 +44,7 @@ public:
 
       std::vector<double> params = getOperationParameters(rxOp);
       if (params.size() != 1) {
-        throw std::runtime_error("Expected a single parameter for RxOp");
+        return;
       }
       if (isMultipleOfTwoPi(params[0])) {
         IRRewriter rewriter(rxOp->getContext());

--- a/lib/Passes/Cancellations/ZeroRyToId.cpp
+++ b/lib/Passes/Cancellations/ZeroRyToId.cpp
@@ -45,7 +45,7 @@ public:
 
       std::vector<double> params = getOperationParameters(ryOp);
       if (params.size() != 1) {
-        throw std::runtime_error("Expected a single parameter for RxOp");
+        return;
       }
       if (isMultipleOfTwoPi(params[0])) {
         IRRewriter rewriter(ryOp->getContext());

--- a/lib/Passes/Cancellations/ZeroRzToId.cpp
+++ b/lib/Passes/Cancellations/ZeroRzToId.cpp
@@ -45,7 +45,7 @@ public:
 
       std::vector<double> params = getOperationParameters(rzOp);
       if (params.size() != 1) {
-        throw std::runtime_error("Expected a single parameter for RxOp");
+        return;
       }
       if (isMultipleOfTwoPi(params[0])) {
         IRRewriter rewriter(rzOp->getContext());

--- a/tests/golden-cases/ZeroRxToIdPass.qke
+++ b/tests/golden-cases/ZeroRxToIdPass.qke
@@ -1,8 +1,9 @@
 module {
-  func.func @__nvqpp__mlirgen__testILm1EE() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+  func.func @__nvqpp__mlirgen__testILm1EE(%arg0: f64) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
     %cst = arith.constant 1.200000e+00 : f64
     %0 = quake.alloca !quake.veq<1>
     %1 = quake.extract_ref %0[0] : (!quake.veq<1>) -> !quake.ref
+    quake.rx (%arg0) %1 : (f64, !quake.ref) -> ()
     quake.rx (%cst) %1 : (f64, !quake.ref) -> ()
     %measOut = quake.mz %0 : (!quake.veq<1>) -> !cc.stdvec<!quake.measure>
     return

--- a/tests/golden-cases/ZeroRyToIdPass.qke
+++ b/tests/golden-cases/ZeroRyToIdPass.qke
@@ -1,8 +1,9 @@
 module {
-  func.func @__nvqpp__mlirgen__testILm1EE() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+  func.func @__nvqpp__mlirgen__testILm1EE(%arg0: f64) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
     %cst = arith.constant 2.000000e+00 : f64
     %0 = quake.alloca !quake.veq<1>
     %1 = quake.extract_ref %0[0] : (!quake.veq<1>) -> !quake.ref
+    quake.ry (%arg0) %1 : (f64, !quake.ref) -> ()
     quake.ry (%cst) %1 : (f64, !quake.ref) -> ()
     %measOut = quake.mz %0 : (!quake.veq<1>) -> !cc.stdvec<!quake.measure>
     return

--- a/tests/golden-cases/ZeroRzToIdPass.qke
+++ b/tests/golden-cases/ZeroRzToIdPass.qke
@@ -1,8 +1,9 @@
 module {
-  func.func @__nvqpp__mlirgen__testILm1EE() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+  func.func @__nvqpp__mlirgen__testILm1EE(%arg0: f64) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
     %cst = arith.constant 1.130000e+01 : f64
     %0 = quake.alloca !quake.veq<1>
     %1 = quake.extract_ref %0[0] : (!quake.veq<1>) -> !quake.ref
+    quake.rz (%arg0) %1 : (f64, !quake.ref) -> ()
     quake.rz (%cst) %1 : (f64, !quake.ref) -> ()
     %measOut = quake.mz %0 : (!quake.veq<1>) -> !cc.stdvec<!quake.measure>
     return

--- a/tests/quake/ZeroRxToIdPass.qke
+++ b/tests/quake/ZeroRxToIdPass.qke
@@ -1,10 +1,11 @@
-func.func @__nvqpp__mlirgen__testILm1EE() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+func.func @__nvqpp__mlirgen__testILm1EE(%arg0: f64) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
   %cst = arith.constant 6.283185e+00 : f64
   %cst_0 = arith.constant 1.200000e+00 : f64
   %cst_1 = arith.constant 0.000000e+00 : f64
   %0 = quake.alloca !quake.veq<1>
   %1 = quake.extract_ref %0[0] : (!quake.veq<1>) -> !quake.ref
   quake.rx (%cst_1) %1 : (f64, !quake.ref) -> ()
+  quake.rx (%arg0) %1 : (f64, !quake.ref) -> ()
   quake.rx (%cst_0) %1 : (f64, !quake.ref) -> ()
   quake.rx (%cst) %1 : (f64, !quake.ref) -> ()
   %measOut = quake.mz %0 : (!quake.veq<1>) -> !cc.stdvec<!quake.measure>

--- a/tests/quake/ZeroRyToIdPass.qke
+++ b/tests/quake/ZeroRyToIdPass.qke
@@ -1,10 +1,11 @@
-func.func @__nvqpp__mlirgen__testILm1EE() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+func.func @__nvqpp__mlirgen__testILm1EE(%arg0: f64) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
   %cst = arith.constant 0.000000e+00 : f64
   %cst_0 = arith.constant 6.283185e+00 : f64
   %cst_1 = arith.constant 2.000000e+00 : f64
   %0 = quake.alloca !quake.veq<1>
   %1 = quake.extract_ref %0[0] : (!quake.veq<1>) -> !quake.ref
   quake.ry (%cst) %1 : (f64, !quake.ref) -> ()
+  quake.ry (%arg0) %1 : (f64, !quake.ref) -> ()
   quake.ry (%cst_1) %1 : (f64, !quake.ref) -> ()
   quake.ry (%cst_0) %1 : (f64, !quake.ref) -> ()
   %measOut = quake.mz %0 : (!quake.veq<1>) -> !cc.stdvec<!quake.measure>

--- a/tests/quake/ZeroRzToIdPass.qke
+++ b/tests/quake/ZeroRzToIdPass.qke
@@ -1,10 +1,11 @@
-func.func @__nvqpp__mlirgen__testILm1EE() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+func.func @__nvqpp__mlirgen__testILm1EE(%arg0: f64) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
   %cst = arith.constant 6.283185e+00 : f64
   %cst_0 = arith.constant 0.000000e+00 : f64
   %cst_1 = arith.constant 1.130000e+01 : f64
   %0 = quake.alloca !quake.veq<1>
   %1 = quake.extract_ref %0[0] : (!quake.veq<1>) -> !quake.ref
   quake.rz (%cst_0) %1 : (f64, !quake.ref) -> ()
+  quake.rz (%arg0) %1 : (f64, !quake.ref) -> ()
   quake.rz (%cst_1) %1 : (f64, !quake.ref) -> ()
   quake.rz (%cst) %1 : (f64, !quake.ref) -> ()
   %measOut = quake.mz %0 : (!quake.veq<1>) -> !cc.stdvec<!quake.measure>


### PR DESCRIPTION
## Summary
- ensure the ZeroRx/Ry/Rz cancellation passes gracefully skip non-constant rotations instead of throwing
- extend the ZeroR{xyz} test inputs and golden files to cover symbolic rotation angles alongside constant zeros

## Testing
- cmake -S . -B build -G Ninja *(fails: MLIRConfig.cmake not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc13a9b7a48332854e88648a36e363