### PR TITLE
Fix CancellationNullRotation pass include guard

### DIFF
--- a/lib/Passes/Transforms/CancellationNullRotation.cpp
+++ b/lib/Passes/Transforms/CancellationNullRotation.cpp
@@ -37,7 +37,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // Include auto-generated pass registration
 namespace mqss::opt {
-#define GEN_PASS_CANCELLATIONNULLROTATION
+#define GEN_PASS_DEF_CANCELLATIONNULLROTATION
 #include "Passes/Transforms.h.inc"
 } // namespace mqss::opt
 using namespace mlir;


### PR DESCRIPTION
## Summary
- update CancellationNullRotation pass to use the GEN_PASS_DEF include guard so it matches the generated header

## Testing
- cmake -S . -B build -G Ninja -DLLVM_DIR=/usr/lib/llvm-20/lib/cmake/llvm -DMLIR_DIR=/usr/lib/llvm-20/lib/cmake/mlir -DCMAKE_BUILD_TYPE=Release *(fails: missing MLIRConfig.cmake)*
- ./build.sh --jobs 4 *(fails: cannot clone CUDA Quantum repository due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1c63b6ac8332b03c6b67ecda9e62