### PR TITLE
Guard optional extraction across utilities

### DIFF
--- a/include/Support/Transforms/CommutateOperations.hpp
+++ b/include/Support/Transforms/CommutateOperations.hpp
@@ -89,10 +89,15 @@ void commuteOperation(mlir::Operation *currentOp, int nCtrlsOp1, int nTgtsOp1,
   if (previousGate.getControls().size() != nCtrlsOp1 ||
       previousGate.getTargets().size() != nTgtsOp1)
     return; // check both targets are the same
-  int targetPrev = extractIndexFromQuakeExtractRefOp(
+  auto targetPrevOpt = extractIndexFromQuakeExtractRefOp(
       previousGate.getTargets()[0].getDefiningOp());
-  int targetCurr = extractIndexFromQuakeExtractRefOp(
+  auto targetCurrOpt = extractIndexFromQuakeExtractRefOp(
       currentGate.getTargets()[0].getDefiningOp());
+  if (!targetPrevOpt.has_value() || !targetCurrOpt.has_value()) {
+    return;
+  }
+  int targetPrev = targetPrevOpt.value();
+  int targetCurr = targetCurrOpt.value();
   if (targetPrev != targetCurr)
     return;
 #ifdef DEBUG

--- a/lib/Interfaces/GatesMap.cpp
+++ b/lib/Interfaces/GatesMap.cpp
@@ -567,13 +567,18 @@ void mqss::interfaces::insertQASMGateIntoQuakeModule(
       auto q2 = targets[1];
       auto param1 = params[1];
       auto param2 = plusHalfPi;
+      auto param0ValueOpt = extractDoubleArgumentValue(
+          params[0].getDefiningOp());
+      auto param1ValueOpt = extractDoubleArgumentValue(
+          params[1].getDefiningOp());
+      if (!param0ValueOpt.has_value() || !param1ValueOpt.has_value()) {
+        return;
+      }
       auto param3 = createFloatValue(
-          builder, loc,
-          -0.5 * extractDoubleArgumentValue(params[0].getDefiningOp()));
+          builder, loc, -0.5 * param0ValueOpt.value());
       auto param4 = minusHalfPi;
       auto param5 = createFloatValue(
-          builder, loc,
-          -extractDoubleArgumentValue(params[1].getDefiningOp()));
+          builder, loc, -param1ValueOpt.value());
       builder.create<quake::RzOp>(loc, false, param1, ValueRange{}, q1);
       builder.create<quake::SOp>(loc, true, ValueRange{}, ValueRange{}, q2);
       builder.create<quake::RxOp>(loc, false, param2, ValueRange{}, q2);
@@ -611,16 +616,20 @@ void mqss::interfaces::insertQASMGateIntoQuakeModule(
           !adj && "ill-formed xx_minus_yy gate");
       auto q1 = targets[0];
       auto q2 = targets[1];
+      auto param0ValueOpt = extractDoubleArgumentValue(
+          params[0].getDefiningOp());
+      auto param1ValueOpt = extractDoubleArgumentValue(
+          params[1].getDefiningOp());
+      if (!param0ValueOpt.has_value() || !param1ValueOpt.has_value()) {
+        return;
+      }
       auto param1 = createFloatValue(
-          builder, loc,
-          -extractDoubleArgumentValue(params[1].getDefiningOp()));
+          builder, loc, -param1ValueOpt.value());
       auto param2 = plusHalfPi;
       auto param3 = createFloatValue(
-          builder, loc,
-          0.5 * extractDoubleArgumentValue(params[0].getDefiningOp()));
+          builder, loc, 0.5 * param0ValueOpt.value());
       auto param4 = createFloatValue(
-          builder, loc,
-          -0.5 * extractDoubleArgumentValue(params[0].getDefiningOp()));
+          builder, loc, -0.5 * param0ValueOpt.value());
       auto param5 = minusHalfPi;
       auto param6 = params[1];
       builder.create<quake::RzOp>(loc, false, param1, ValueRange{}, q2);

--- a/lib/Passes/CodeGen/QuakeToTikz.cpp
+++ b/lib/Passes/CodeGen/QuakeToTikz.cpp
@@ -65,8 +65,12 @@ void dumpQuakeOperationToTikz(
   if (isa<quake::MxOp>(op) || isa<quake::MyOp>(op) || isa<quake::MzOp>(op)) {
     for (auto operand : op->getOperands()) {
       if (operand.getType().isa<quake::RefType>()) {
-        int qubitIndex =
-            extractIndexFromQuakeExtractRefOp(operand.getDefiningOp());
+        auto qubitIndexOpt
+            = extractIndexFromQuakeExtractRefOp(operand.getDefiningOp());
+        if (!qubitIndexOpt.has_value()) {
+          continue;
+        }
+        int qubitIndex = qubitIndexOpt.value();
         assert(qubitIndex != -1 && "Non valid qubit index for measurement!");
         measurements.push_back(qubitIndex);
         qubitLines[qubitIndex].push_back("\\meter{}");

--- a/lib/Passes/Transforms/QuakeQMap.cpp
+++ b/lib/Passes/Transforms/QuakeQMap.cpp
@@ -47,11 +47,19 @@ void loadRotationGatesToQC(Operation *op, qc::QuantumComputation &qc) {
   if (isa<quake::RxOp>(op) || isa<quake::RyOp>(op) || isa<quake::RzOp>(op)) {
     assert(op->getOperands().size() == 2 && "ill-formed rotation gate!");
     Value operand1 = op->getOperands()[0];
-    double angle = supportQuake::extractDoubleArgumentValue(
+    auto angleOpt = supportQuake::extractDoubleArgumentValue(
         operand1.getDefiningOp());
+    if (!angleOpt.has_value()) {
+      return;
+    }
+    double angle = angleOpt.value();
     Value operand2 = op->getOperands()[1];
-    int qubit = supportQuake::extractIndexFromQuakeExtractRefOp(
+    auto qubitOpt = supportQuake::extractIndexFromQuakeExtractRefOp(
         operand2.getDefiningOp());
+    if (!qubitOpt.has_value()) {
+      return;
+    }
+    int qubit = qubitOpt.value();
 #ifdef DEBUG
     llvm::errs() << "Operation ";
     op->print(llvm::errs());
@@ -80,11 +88,16 @@ void loadXYZGatesToQC(Operation *op, qc::QuantumComputation &qc) {
     // controlled operations
     if (op->getOperands().size() == 2) {
       Value operand1 = op->getOperands()[0];
-      int qubit_ctrl = supportQuake::extractIndexFromQuakeExtractRefOp(
+      auto qubitCtrlOpt = supportQuake::extractIndexFromQuakeExtractRefOp(
           operand1.getDefiningOp());
       Value operand2 = op->getOperands()[1];
-      int qubit_target = supportQuake::extractIndexFromQuakeExtractRefOp(
+      auto qubitTargetOpt = supportQuake::extractIndexFromQuakeExtractRefOp(
           operand2.getDefiningOp());
+      if (!qubitCtrlOpt.has_value() || !qubitTargetOpt.has_value()) {
+        return;
+      }
+      int qubit_ctrl = qubitCtrlOpt.value();
+      int qubit_target = qubitTargetOpt.value();
 #ifdef DEBUG
       llvm::errs() << "Operation ";
       op->print(llvm::errs());
@@ -104,8 +117,12 @@ void loadXYZGatesToQC(Operation *op, qc::QuantumComputation &qc) {
     // single qubit operations
     if (op->getOperands().size() == 1) {
       Value operand1 = op->getOperands()[0];
-      int qubit = supportQuake::extractIndexFromQuakeExtractRefOp(
+      auto qubitOpt = supportQuake::extractIndexFromQuakeExtractRefOp(
           operand1.getDefiningOp());
+      if (!qubitOpt.has_value()) {
+        return;
+      }
+      int qubit = qubitOpt.value();
 #ifdef DEBUG
       llvm::errs() << "Operation ";
       op->print(llvm::errs());
@@ -129,8 +146,12 @@ void loadSTHGatesToQC(Operation *op, qc::QuantumComputation &qc) {
     // single qubit operations
     if (op->getOperands().size() == 1) {
       Value operand1 = op->getOperands()[0];
-      int qubit = supportQuake::extractIndexFromQuakeExtractRefOp(
+      auto qubitOpt = supportQuake::extractIndexFromQuakeExtractRefOp(
           operand1.getDefiningOp());
+      if (!qubitOpt.has_value()) {
+        return;
+      }
+      int qubit = qubitOpt.value();
 #ifdef DEBUG
       llvm::errs() << "Operation ";
       op->print(llvm::errs());
@@ -160,8 +181,12 @@ void loadMeasurementsToQC(Operation *op, qc::QuantumComputation &qc,
     assert(op->getOperands().size() == 1 && "ill-formed measurement gate!");
     if (Value operand = op->getOperands()[0];
       operand.getType().isa<quake::RefType>()) {
-      int qubitIndex = supportQuake::extractIndexFromQuakeExtractRefOp(
+      auto qubitIndexOpt = supportQuake::extractIndexFromQuakeExtractRefOp(
           operand.getDefiningOp());
+      if (!qubitIndexOpt.has_value()) {
+        return;
+      }
+      int qubitIndex = qubitIndexOpt.value();
       assert(qubitIndex != -1 && "Non valid qubit index for measurement!");
       qc.measure(static_cast<qc::Qubit>(qubitIndex),
                  measurements.at(qubitIndex));

--- a/lib/Passes/Transforms/ZCxToCxZ.cpp
+++ b/lib/Passes/Transforms/ZCxToCxZ.cpp
@@ -57,11 +57,14 @@ void commuteZCx(Operation *currentOp) {
       previousGate.getTargets().size() != 1) {
     return;
   }
-  int targetPrev = supportQuake::extractIndexFromQuakeExtractRefOp(
+  auto targetPrevOpt = supportQuake::extractIndexFromQuakeExtractRefOp(
       previousGate.getTargets()[0].getDefiningOp());
-  int controlCurr = supportQuake::extractIndexFromQuakeExtractRefOp(
+  auto controlCurrOpt = supportQuake::extractIndexFromQuakeExtractRefOp(
       currentGate.getControls()[0].getDefiningOp());
-  if (targetPrev == controlCurr) {
+  if (!targetPrevOpt.has_value() || !controlCurrOpt.has_value()) {
+    return;
+  }
+  if (targetPrevOpt.value() == controlCurrOpt.value()) {
     IRRewriter rewriter(currentGate->getContext());
     rewriter.setInsertionPointAfter(currentGate);
     rewriter.create<quake::ZOp>(

--- a/lib/Support/CodeGen/Quake/QuakeOperations.cpp
+++ b/lib/Support/CodeGen/Quake/QuakeOperations.cpp
@@ -184,9 +184,12 @@ int getNumberOfGates(FuncOp circuit) {
     if (isMeasurementGate(op)) {
       for (auto operand : op->getOperands()) {
         if (operand.getType().isa<quake::RefType>()) {
-          int qubitIndex =
-              extractIndexFromQuakeExtractRefOp(operand.getDefiningOp()).
-              value();
+          auto qubitIndexOpt =
+              extractIndexFromQuakeExtractRefOp(operand.getDefiningOp());
+          if (!qubitIndexOpt.has_value()) {
+            continue;
+          }
+          int qubitIndex = qubitIndexOpt.value();
           if (0 <= qubitIndex && qubitIndex < nrQubits) {
             nrGates++;
           }
@@ -221,9 +224,12 @@ int getCircuitDepth(FuncOp circuit) {
     if (isMeasurementGate(op)) {
       for (auto operand : op->getOperands()) {
         if (operand.getType().isa<quake::RefType>()) {
-          int qubitIndex =
-              extractIndexFromQuakeExtractRefOp(operand.getDefiningOp()).
-              value();
+          auto qubitIndexOpt =
+              extractIndexFromQuakeExtractRefOp(operand.getDefiningOp());
+          if (!qubitIndexOpt.has_value()) {
+            continue;
+          }
+          int qubitIndex = qubitIndexOpt.value();
           if (0 <= qubitIndex && qubitIndex < nrQubits) {
             depths[qubitIndex]++;
           }
@@ -270,9 +276,12 @@ int getNumberOfClassicalBits(
       for (auto operand : op->getOperands()) {
         // Check if it's qubit reference
         if (operand.getType().isa<quake::RefType>()) {
-          int qubitIndex =
-              extractIndexFromQuakeExtractRefOp(operand.getDefiningOp()).
-              value();
+          auto qubitIndexOpt =
+              extractIndexFromQuakeExtractRefOp(operand.getDefiningOp());
+          if (!qubitIndexOpt.has_value()) {
+            continue;
+          }
+          int qubitIndex = qubitIndexOpt.value();
           assert(qubitIndex != -1 && "Non valid qubit index for measurement!");
           measurements[qubitIndex] = numBits;
           numBits += 1;
@@ -309,9 +318,12 @@ int getNumberOfClassicalBits(FuncOp circuit) {
         if (operand.getType()
           .isa<quake::RefType>()) {
           // Check if it's a qubit reference
-          int qubitIndex =
-              extractIndexFromQuakeExtractRefOp(operand.getDefiningOp()).
-              value();
+          auto qubitIndexOpt =
+              extractIndexFromQuakeExtractRefOp(operand.getDefiningOp());
+          if (!qubitIndexOpt.has_value()) {
+            continue;
+          }
+          int qubitIndex = qubitIndexOpt.value();
           assert(qubitIndex != -1 && "Non valid qubit index for measurement!");
           numBits += 1;
         } else if (operand.getType().isa<quake::VeqType>()) {
@@ -329,9 +341,13 @@ std::vector<int>
 getIndicesOfValueRange(const ValueRange array) {
   std::vector<int> indices;
   for (auto value : array) {
-    int qubit_index = extractIndexFromQuakeExtractRefOp(value.getDefiningOp()).
-        value();
-    indices.push_back(qubit_index);
+    auto qubitIndexOpt =
+        extractIndexFromQuakeExtractRefOp(value.getDefiningOp());
+    if (!qubitIndexOpt.has_value()) {
+      continue;
+    }
+    int qubitIndex = qubitIndexOpt.value();
+    indices.push_back(qubitIndex);
   }
   return indices;
 }
@@ -341,7 +357,11 @@ std::vector<double>
 getParametersValues(const ValueRange array) {
   std::vector<double> parameters;
   for (auto value : array) {
-    double param = extractDoubleArgumentValue(value.getDefiningOp()).value();
+    auto paramOpt = extractDoubleArgumentValue(value.getDefiningOp());
+    if (!paramOpt.has_value()) {
+      continue;
+    }
+    double param = paramOpt.value();
     parameters.push_back(param);
   }
   return parameters;
@@ -351,23 +371,35 @@ getParametersValues(const ValueRange array) {
 // currentOp
 Operation *getPreviousOperationOnTarget(
     Operation *currentOp, Value targetQubit) {
+  auto targetQCurrOpt =
+      extractIndexFromQuakeExtractRefOp(targetQubit.getDefiningOp());
+  if (!targetQCurrOpt.has_value()) {
+    return nullptr;
+  }
+  int targetQCurr = targetQCurrOpt.value();
   // Start from the previous operation
   Operation *prevOp = currentOp->getPrevNode();
   // Iterate through the previous operations in the block
   while (prevOp) {
     // Check if the operation has a target qubit and matches the given target
     if (auto quakeOp = dyn_cast<quake::OperatorInterface>(prevOp)) {
-      int targetQCurr = extractIndexFromQuakeExtractRefOp(
-          targetQubit.getDefiningOp()).value();
       for (Value target : quakeOp.getTargets()) {
-        int targetQPrev = extractIndexFromQuakeExtractRefOp(
-            target.getDefiningOp()).value();
+        auto targetQPrevOpt =
+            extractIndexFromQuakeExtractRefOp(target.getDefiningOp());
+        if (!targetQPrevOpt.has_value()) {
+          continue;
+        }
+        int targetQPrev = targetQPrevOpt.value();
         if (targetQCurr == targetQPrev)
           return prevOp;
       }
       for (Value control : quakeOp.getControls()) {
-        int controlQPrev = extractIndexFromQuakeExtractRefOp(
-            control.getDefiningOp()).value();
+        auto controlQPrevOpt =
+            extractIndexFromQuakeExtractRefOp(control.getDefiningOp());
+        if (!controlQPrevOpt.has_value()) {
+          continue;
+        }
+        int controlQPrev = controlQPrevOpt.value();
         if (targetQCurr == controlQPrev)
           return prevOp;
       }
@@ -382,24 +414,36 @@ Operation *getPreviousOperationOnTarget(
 // currentOp
 Operation *getNextOperationOnTarget(
     Operation *currentOp, Value targetQubit) {
+  auto targetQCurrOpt =
+      extractIndexFromQuakeExtractRefOp(targetQubit.getDefiningOp());
+  if (!targetQCurrOpt.has_value()) {
+    return nullptr;
+  }
+  int targetQCurr = targetQCurrOpt.value();
   // Start from the next operation
   Operation *nextOp = currentOp->getNextNode();
   // Iterate through the previous operations in the block
   while (nextOp) {
     // Check if the operation has a target qubit and matches the given target
     if (auto quakeOp = dyn_cast<quake::OperatorInterface>(nextOp)) {
-      int targetQCurr = extractIndexFromQuakeExtractRefOp(
-          targetQubit.getDefiningOp()).value();
       for (Value target : quakeOp.getTargets()) {
-        int targetQNext = extractIndexFromQuakeExtractRefOp(
-            target.getDefiningOp()).value();
+        auto targetQNextOpt =
+            extractIndexFromQuakeExtractRefOp(target.getDefiningOp());
+        if (!targetQNextOpt.has_value()) {
+          continue;
+        }
+        int targetQNext = targetQNextOpt.value();
         if (targetQCurr == targetQNext) {
           return nextOp;
         }
       }
       for (Value control : quakeOp.getControls()) {
-        int controlQNext = extractIndexFromQuakeExtractRefOp(
-            control.getDefiningOp()).value();
+        auto controlQNextOpt =
+            extractIndexFromQuakeExtractRefOp(control.getDefiningOp());
+        if (!controlQNextOpt.has_value()) {
+          continue;
+        }
+        int controlQNext = controlQNextOpt.value();
         if (targetQCurr == controlQNext) {
           return nextOp;
         }

--- a/lib/Support/mlir_utils.cpp
+++ b/lib/Support/mlir_utils.cpp
@@ -87,8 +87,12 @@ std::vector<int> getMeasurementTargets(Operation *op, int nr_qubits) {
   }
   if (auto operand = op->getOpOperands().front().get();
     operand.getType().isa<quake::RefType>()) {
-    targets.push_back(
-        extractIndexFromQuakeExtractRefOp(operand.getDefiningOp()));
+    auto targetIndexOpt
+        = extractIndexFromQuakeExtractRefOp(operand.getDefiningOp());
+    if (!targetIndexOpt.has_value()) {
+      return {};
+    }
+    targets.push_back(targetIndexOpt.value());
   } else if (operand.getType().isa<quake::VeqType>()) {
     // Because this function only works for a single allocation, the
     // reference to a Veq will reference all allocated qubits in the
@@ -126,8 +130,12 @@ getQubitsInstructionsDepth(FuncOp circuit) {
     if (isMeasurementGate(op)) {
       for (auto operand : op->getOperands()) {
         if (operand.getType().isa<quake::RefType>()) {
-          int qubitIndex =
-              extractIndexFromQuakeExtractRefOp(operand.getDefiningOp());
+          auto qubitIndexOpt
+              = extractIndexFromQuakeExtractRefOp(operand.getDefiningOp());
+          if (!qubitIndexOpt.has_value()) {
+            continue;
+          }
+          int qubitIndex = qubitIndexOpt.value();
           if (0 <= qubitIndex && qubitIndex < nrQubits) {
             nrGates++;
             depths[qubitIndex]++;


### PR DESCRIPTION
## Summary
- guard qubit index extraction within commuting helper to avoid using empty optionals
- validate measurement and gate index extraction across support utilities and TikZ export before consuming the values
- ensure mapping and gate synthesis helpers bail out when rotation parameters or qubit indices cannot be derived

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc2e2d4f3883329c1d0a137d15f95e