### PR TITLE
Refactor transform passes to use previous operation lookups

### DIFF
--- a/lib/Passes/Transforms/CxCxCxToSwap.cpp
+++ b/lib/Passes/Transforms/CxCxCxToSwap.cpp
@@ -32,16 +32,16 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto cxOp1 = dyn_cast_or_null<quake::XOp>(op);
-      if (!cxOp1
-          || cxOp1.getTargets().size() != 1
-          || cxOp1.getControls().size() != 1) {
+      auto cxOp3 = dyn_cast_or_null<quake::XOp>(op);
+      if (!cxOp3
+          || cxOp3.getTargets().size() != 1
+          || cxOp3.getControls().size() != 1) {
         return;
       }
       auto optional_cxOp2_onTarget
-          = getNextOperationOnTarget(cxOp1, cxOp1.getTargets()[0]);
+          = getPreviousOperationOnTarget(cxOp3, cxOp3.getTargets()[0]);
       auto optional_cxOp2_onControl
-          = getNextOperationOnTarget(cxOp1, cxOp1.getControls()[0]);
+          = getPreviousOperationOnTarget(cxOp3, cxOp3.getControls()[0]);
       if (!optional_cxOp2_onTarget
           || !optional_cxOp2_onControl
           || optional_cxOp2_onTarget != optional_cxOp2_onControl) {
@@ -52,28 +52,30 @@ public:
       if (!cxOp2
           || cxOp2.getTargets().size() != 1
           || cxOp2.getControls().size() != 1
+          || cxOp2.getControls()[0] != cxOp3.getTargets()[0]
+          || cxOp2.getTargets()[0] != cxOp3.getControls()[0]) {
+        return;
+      }
+      auto optional_cxOp1_onTarget
+          = getPreviousOperationOnTarget(cxOp2, cxOp2.getTargets()[0]);
+      auto optional_cxOp1_onControl
+          = getPreviousOperationOnTarget(cxOp2, cxOp2.getControls()[0]);
+      if (!optional_cxOp1_onTarget
+          || !optional_cxOp1_onControl
+          || optional_cxOp1_onTarget != optional_cxOp1_onControl) {
+        return;
+      }
+      auto cxOp1 = dyn_cast_or_null<quake::XOp>(optional_cxOp1_onTarget);
+      if (!cxOp1
+          || cxOp1.getTargets().size() != 1
+          || cxOp1.getControls().size() != 1
           || cxOp2.getControls()[0] != cxOp1.getTargets()[0]
-          || cxOp2.getTargets()[0] != cxOp1.getControls()[0]) {
-        return;
-      }
-      auto optional_cxOp3_onTarget
-          = getNextOperationOnTarget(cxOp2, cxOp2.getTargets()[0]);
-      auto optional_cxOp3_onControl
-          = getNextOperationOnTarget(cxOp2, cxOp2.getControls()[0]);
-      if (!optional_cxOp3_onTarget
-          || !optional_cxOp3_onControl
-          || optional_cxOp3_onTarget != optional_cxOp3_onControl) {
-        return;
-      }
-      auto cxOp3 = dyn_cast_or_null<quake::XOp>(optional_cxOp3_onTarget);
-      if (!cxOp3
-          || cxOp3.getTargets().size() != 1
-          || cxOp3.getControls().size() != 1
+          || cxOp2.getTargets()[0] != cxOp1.getControls()[0]
           || cxOp3.getControls()[0] != cxOp1.getControls()[0]
           || cxOp3.getTargets()[0] != cxOp1.getTargets()[0]) {
         return;
       }
-      IRRewriter rewriter(cxOp1->getContext());
+      IRRewriter rewriter(cxOp3->getContext());
       rewriter.setInsertionPointAfter(cxOp3);
       ValueRange targets{cxOp1.getControls()[0], cxOp1.getTargets()[0]};
       Location loc = cxOp1.getLoc();

--- a/lib/Passes/Transforms/CxRxToRxCx.cpp
+++ b/lib/Passes/Transforms/CxRxToRxCx.cpp
@@ -31,18 +31,7 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto cxOp = dyn_cast_or_null<quake::XOp>(op);
-      if (!cxOp
-          || cxOp.getTargets().size() != 1
-          || cxOp.getControls().size() != 1) {
-        return;
-      }
-      auto optional_rxOp
-          = getNextOperationOnTarget(cxOp, cxOp.getTargets()[0]);
-      if (!optional_rxOp) {
-        return;
-      }
-      auto rxOp = dyn_cast_or_null<quake::RxOp>(optional_rxOp);
+      auto rxOp = dyn_cast_or_null<quake::RxOp>(op);
       if (!rxOp
           || rxOp.isAdj()
           || rxOp.getTargets().size() != 1
@@ -50,7 +39,18 @@ public:
           || rxOp.getParameters().size() != 1) {
         return;
       }
-      IRRewriter rewriter(cxOp->getContext());
+      auto optional_cxOp
+          = getPreviousOperationOnTarget(rxOp, rxOp.getTargets()[0]);
+      if (!optional_cxOp) {
+        return;
+      }
+      auto cxOp = dyn_cast_or_null<quake::XOp>(optional_cxOp);
+      if (!cxOp
+          || cxOp.getTargets().size() != 1
+          || cxOp.getControls().size() != 1) {
+        return;
+      }
+      IRRewriter rewriter(rxOp->getContext());
       rewriter.setInsertionPointAfter(rxOp);
       ValueRange targets = cxOp.getTargets();
       ValueRange controls = cxOp.getControls();

--- a/lib/Passes/Transforms/CxXToXCx.cpp
+++ b/lib/Passes/Transforms/CxXToXCx.cpp
@@ -31,24 +31,24 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto cxOp = dyn_cast_or_null<quake::XOp>(op);
-      if (!cxOp
-          || cxOp.getTargets().size() != 1
-          || cxOp.getControls().size() != 1) {
-        return;
-      }
-      auto optional_xOp
-          = getNextOperationOnTarget(cxOp, cxOp.getTargets()[0]);
-      if (!optional_xOp) {
-        return;
-      }
-      auto xOp = dyn_cast_or_null<quake::XOp>(optional_xOp);
+      auto xOp = dyn_cast_or_null<quake::XOp>(op);
       if (!xOp
           || xOp.getTargets().size() != 1
           || !xOp.getControls().empty()) {
         return;
       }
-      IRRewriter rewriter(cxOp->getContext());
+      auto optional_cxOp
+          = getPreviousOperationOnTarget(xOp, xOp.getTargets()[0]);
+      if (!optional_cxOp) {
+        return;
+      }
+      auto cxOp = dyn_cast_or_null<quake::XOp>(optional_cxOp);
+      if (!cxOp
+          || cxOp.getTargets().size() != 1
+          || cxOp.getControls().size() != 1) {
+        return;
+      }
+      IRRewriter rewriter(xOp->getContext());
       rewriter.setInsertionPointAfter(xOp);
       ValueRange targets = cxOp.getTargets();
       ValueRange controls = cxOp.getControls();

--- a/lib/Passes/Transforms/CxZToZCx.cpp
+++ b/lib/Passes/Transforms/CxZToZCx.cpp
@@ -31,24 +31,24 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto cxOp = dyn_cast_or_null<quake::XOp>(op);
-      if (!cxOp
-          || cxOp.getTargets().size() != 1
-          || cxOp.getControls().size() != 1) {
-        return;
-      }
-      auto optional_zOp
-          = getNextOperationOnTarget(cxOp, cxOp.getControls()[0]);
-      if (!optional_zOp) {
-        return;
-      }
-      auto zOp = dyn_cast_or_null<quake::ZOp>(optional_zOp);
+      auto zOp = dyn_cast_or_null<quake::ZOp>(op);
       if (!zOp
           || zOp.getTargets().size() != 1
           || !zOp.getControls().empty()) {
         return;
       }
-      IRRewriter rewriter(cxOp->getContext());
+      auto optional_cxOp
+          = getPreviousOperationOnTarget(zOp, zOp.getTargets()[0]);
+      if (!optional_cxOp) {
+        return;
+      }
+      auto cxOp = dyn_cast_or_null<quake::XOp>(optional_cxOp);
+      if (!cxOp
+          || cxOp.getTargets().size() != 1
+          || cxOp.getControls().size() != 1) {
+        return;
+      }
+      IRRewriter rewriter(zOp->getContext());
       rewriter.setInsertionPointAfter(zOp);
       ValueRange targets = cxOp.getTargets();
       ValueRange controls = cxOp.getControls();

--- a/lib/Passes/Transforms/HCrxHToCrz.cpp
+++ b/lib/Passes/Transforms/HCrxHToCrz.cpp
@@ -32,14 +32,14 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto hOp1 = dyn_cast_or_null<quake::HOp>(op);
-      if (!hOp1
-          || hOp1.getTargets().size() != 1
-          || !hOp1.getControls().empty()) {
+      auto hOp2 = dyn_cast_or_null<quake::HOp>(op);
+      if (!hOp2
+          || hOp2.getTargets().size() != 1
+          || !hOp2.getControls().empty()) {
         return;
       }
       auto optional_crxOp
-          = getNextOperationOnTarget(hOp1, hOp1.getTargets()[0]);
+          = getPreviousOperationOnTarget(hOp2, hOp2.getTargets()[0]);
       if (!optional_crxOp) {
         return;
       }
@@ -51,18 +51,18 @@ public:
           || crxOp.getParameters().size() != 1) {
         return;
       }
-      auto optional_hOp2
-          = getNextOperationOnTarget(crxOp, crxOp.getTargets()[0]);
-      if (!optional_hOp2) {
+      auto optional_hOp1
+          = getPreviousOperationOnTarget(crxOp, crxOp.getTargets()[0]);
+      if (!optional_hOp1) {
         return;
       }
-      auto hOp2 = dyn_cast_or_null<quake::HOp>(optional_hOp2);
-      if (!hOp2
-          || hOp2.getTargets().size() != 1
-          || !hOp2.getControls().empty()) {
+      auto hOp1 = dyn_cast_or_null<quake::HOp>(optional_hOp1);
+      if (!hOp1
+          || hOp1.getTargets().size() != 1
+          || !hOp1.getControls().empty()) {
         return;
       }
-      IRRewriter rewriter(op->getContext());
+      IRRewriter rewriter(hOp2->getContext());
       rewriter.setInsertionPointAfter(hOp2);
       ValueRange targets = crxOp.getTargets();
       ValueRange controls = crxOp.getControls();

--- a/lib/Passes/Transforms/HCrzHToCrx.cpp
+++ b/lib/Passes/Transforms/HCrzHToCrx.cpp
@@ -31,14 +31,14 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto hOp1 = dyn_cast_or_null<quake::HOp>(op);
-      if (!hOp1
-          || hOp1.getTargets().size() != 1
-          || !hOp1.getControls().empty()) {
+      auto hOp2 = dyn_cast_or_null<quake::HOp>(op);
+      if (!hOp2
+          || hOp2.getTargets().size() != 1
+          || !hOp2.getControls().empty()) {
         return;
       }
       auto optional_crzOp
-          = getNextOperationOnTarget(hOp1, hOp1.getTargets()[0]);
+          = getPreviousOperationOnTarget(hOp2, hOp2.getTargets()[0]);
       if (!optional_crzOp) {
         return;
       }
@@ -50,18 +50,18 @@ public:
           || crzOp.getParameters().size() != 1) {
         return;
       }
-      auto optional_hOp2
-          = getNextOperationOnTarget(crzOp, crzOp.getTargets()[0]);
-      if (!optional_hOp2) {
+      auto optional_hOp1
+          = getPreviousOperationOnTarget(crzOp, crzOp.getTargets()[0]);
+      if (!optional_hOp1) {
         return;
       }
-      auto hOp2 = dyn_cast_or_null<quake::HOp>(optional_hOp2);
-      if (!hOp2
-          || hOp2.getTargets().size() != 1
-          || !hOp2.getControls().empty()) {
+      auto hOp1 = dyn_cast_or_null<quake::HOp>(optional_hOp1);
+      if (!hOp1
+          || hOp1.getTargets().size() != 1
+          || !hOp1.getControls().empty()) {
         return;
       }
-      IRRewriter rewriter(hOp1->getContext());
+      IRRewriter rewriter(hOp2->getContext());
       rewriter.setInsertionPointAfter(hOp2);
       ValueRange targets = hOp1.getTargets();
       ValueRange controls = crzOp.getControls();

--- a/lib/Passes/Transforms/HCxHToCz.cpp
+++ b/lib/Passes/Transforms/HCxHToCz.cpp
@@ -31,14 +31,14 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto hOp1 = dyn_cast_or_null<quake::HOp>(op);
-      if (!hOp1
-          || hOp1.getTargets().size() != 1
-          || !hOp1.getControls().empty()) {
+      auto hOp2 = dyn_cast_or_null<quake::HOp>(op);
+      if (!hOp2
+          || hOp2.getTargets().size() != 1
+          || !hOp2.getControls().empty()) {
         return;
       }
       auto optional_cxOp
-          = getNextOperationOnTarget(hOp1, hOp1.getTargets()[0]);
+          = getPreviousOperationOnTarget(hOp2, hOp2.getTargets()[0]);
       if (!optional_cxOp) {
         return;
       }
@@ -48,18 +48,18 @@ public:
           || cxOp.getControls().size() != 1) {
         return;
       }
-      auto optional_hOp2
-          = getNextOperationOnTarget(cxOp, cxOp.getTargets()[0]);
-      if (!optional_hOp2) {
+      auto optional_hOp1
+          = getPreviousOperationOnTarget(cxOp, cxOp.getTargets()[0]);
+      if (!optional_hOp1) {
         return;
       }
-      auto hOp2 = dyn_cast_or_null<quake::HOp>(optional_hOp2);
-      if (!hOp2
-          || hOp2.getTargets().size() != 1
-          || !hOp2.getControls().empty()) {
+      auto hOp1 = dyn_cast_or_null<quake::HOp>(optional_hOp1);
+      if (!hOp1
+          || hOp1.getTargets().size() != 1
+          || !hOp1.getControls().empty()) {
         return;
       }
-      IRRewriter rewriter(cxOp->getContext());
+      IRRewriter rewriter(hOp2->getContext());
       rewriter.setInsertionPointAfter(hOp2);
       ValueRange targets = cxOp.getTargets();
       ValueRange controls = cxOp.getControls();

--- a/lib/Passes/Transforms/HCzHToCx.cpp
+++ b/lib/Passes/Transforms/HCzHToCx.cpp
@@ -31,14 +31,14 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto hOp1 = dyn_cast_or_null<quake::HOp>(op);
-      if (!hOp1
-          || hOp1.getTargets().size() != 1
-          || !hOp1.getControls().empty()) {
+      auto hOp2 = dyn_cast_or_null<quake::HOp>(op);
+      if (!hOp2
+          || hOp2.getTargets().size() != 1
+          || !hOp2.getControls().empty()) {
         return;
       }
       auto optional_czOp
-          = getNextOperationOnTarget(hOp1, hOp1.getTargets()[0]);
+          = getPreviousOperationOnTarget(hOp2, hOp2.getTargets()[0]);
       if (!optional_czOp) {
         return;
       }
@@ -48,18 +48,18 @@ public:
           || czOp.getControls().size() != 1) {
         return;
       }
-      auto optional_hOp2
-          = getNextOperationOnTarget(czOp, czOp.getTargets()[0]);
-      if (!optional_hOp2) {
+      auto optional_hOp1
+          = getPreviousOperationOnTarget(czOp, czOp.getTargets()[0]);
+      if (!optional_hOp1) {
         return;
       }
-      auto hOp2 = dyn_cast_or_null<quake::HOp>(optional_hOp2);
-      if (!hOp2
-          || hOp2.getTargets().size() != 1
-          || !hOp2.getControls().empty()) {
+      auto hOp1 = dyn_cast_or_null<quake::HOp>(optional_hOp1);
+      if (!hOp1
+          || hOp1.getTargets().size() != 1
+          || !hOp1.getControls().empty()) {
         return;
       }
-      IRRewriter rewriter(czOp->getContext());
+      IRRewriter rewriter(hOp2->getContext());
       rewriter.setInsertionPointAfter(hOp2);
       ValueRange targets = czOp.getTargets();
       ValueRange controls = czOp.getControls();

--- a/lib/Passes/Transforms/HRxHToRz.cpp
+++ b/lib/Passes/Transforms/HRxHToRz.cpp
@@ -31,14 +31,14 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto hOp1 = dyn_cast_or_null<quake::HOp>(op);
-      if (!hOp1
-          || hOp1.getTargets().size() != 1
-          || !hOp1.getControls().empty()) {
+      auto hOp2 = dyn_cast_or_null<quake::HOp>(op);
+      if (!hOp2
+          || hOp2.getTargets().size() != 1
+          || !hOp2.getControls().empty()) {
         return;
       }
       auto optional_rxOp
-          = getNextOperationOnTarget(hOp1, hOp1.getTargets()[0]);
+          = getPreviousOperationOnTarget(hOp2, hOp2.getTargets()[0]);
       if (!optional_rxOp) {
         return;
       }
@@ -50,18 +50,18 @@ public:
           || rxOp.getParameters().size() != 1) {
         return;
       }
-      auto optional_hOp2
-          = getNextOperationOnTarget(rxOp, rxOp.getTargets()[0]);
-      if (!optional_hOp2) {
+      auto optional_hOp1
+          = getPreviousOperationOnTarget(rxOp, rxOp.getTargets()[0]);
+      if (!optional_hOp1) {
         return;
       }
-      auto hOp2 = dyn_cast_or_null<quake::HOp>(optional_hOp2);
-      if (!hOp2
-          || hOp2.getTargets().size() != 1
-          || !hOp2.getControls().empty()) {
+      auto hOp1 = dyn_cast_or_null<quake::HOp>(optional_hOp1);
+      if (!hOp1
+          || hOp1.getTargets().size() != 1
+          || !hOp1.getControls().empty()) {
         return;
       }
-      IRRewriter rewriter(hOp1->getContext());
+      IRRewriter rewriter(hOp2->getContext());
       rewriter.setInsertionPointAfter(hOp2);
       ValueRange targets = hOp1.getTargets();
       ValueRange params = rxOp.getParameters();

--- a/lib/Passes/Transforms/HRzHToRx.cpp
+++ b/lib/Passes/Transforms/HRzHToRx.cpp
@@ -31,14 +31,14 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto hOp1 = dyn_cast_or_null<quake::HOp>(op);
-      if (!hOp1
-          || hOp1.getTargets().size() != 1
-          || !hOp1.getControls().empty()) {
+      auto hOp2 = dyn_cast_or_null<quake::HOp>(op);
+      if (!hOp2
+          || hOp2.getTargets().size() != 1
+          || !hOp2.getControls().empty()) {
         return;
       }
       auto optional_rzOp
-          = getNextOperationOnTarget(hOp1, hOp1.getTargets()[0]);
+          = getPreviousOperationOnTarget(hOp2, hOp2.getTargets()[0]);
       if (!optional_rzOp) {
         return;
       }
@@ -50,19 +50,19 @@ public:
           || rzOp.getParameters().size() != 1) {
         return;
       }
-      auto optional_hOp2
-          = getNextOperationOnTarget(rzOp, rzOp.getTargets()[0]);
-      if (!optional_hOp2) {
+      auto optional_hOp1
+          = getPreviousOperationOnTarget(rzOp, rzOp.getTargets()[0]);
+      if (!optional_hOp1) {
         return;
       }
-      auto hOp2 = dyn_cast_or_null<quake::HOp>(optional_hOp2);
-      if (!hOp2
-          || hOp2.getTargets().size() != 1
-          || !hOp2.getControls().empty()
+      auto hOp1 = dyn_cast_or_null<quake::HOp>(optional_hOp1);
+      if (!hOp1
+          || hOp1.getTargets().size() != 1
+          || !hOp1.getControls().empty()
           || hOp2.getTargets()[0] != hOp1.getTargets()[0]) {
         return;
       }
-      IRRewriter rewriter(hOp1->getContext());
+      IRRewriter rewriter(hOp2->getContext());
       rewriter.setInsertionPointAfter(hOp2);
       ValueRange targets = hOp1.getTargets();
       ValueRange params = rzOp.getParameters();

--- a/lib/Passes/Transforms/HXHToZ.cpp
+++ b/lib/Passes/Transforms/HXHToZ.cpp
@@ -31,14 +31,14 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto hOp1 = dyn_cast_or_null<quake::HOp>(op);
-      if (!hOp1
-          || hOp1.getTargets().size() != 1
-          || !hOp1.getControls().empty()) {
+      auto hOp2 = dyn_cast_or_null<quake::HOp>(op);
+      if (!hOp2
+          || hOp2.getTargets().size() != 1
+          || !hOp2.getControls().empty()) {
         return;
       }
       auto optional_xOp
-          = getNextOperationOnTarget(hOp1, hOp1.getTargets()[0]);
+          = getPreviousOperationOnTarget(hOp2, hOp2.getTargets()[0]);
       if (!optional_xOp) {
         return;
       }
@@ -48,18 +48,18 @@ public:
           || !xOp.getControls().empty()) {
         return;
       }
-      auto optional_hOp2
-          = getNextOperationOnTarget(xOp, xOp.getTargets()[0]);
-      if (!optional_hOp2) {
+      auto optional_hOp1
+          = getPreviousOperationOnTarget(xOp, xOp.getTargets()[0]);
+      if (!optional_hOp1) {
         return;
       }
-      auto hOp2 = dyn_cast_or_null<quake::HOp>(optional_hOp2);
-      if (!hOp2
-          || hOp2.getTargets().size() != 1
-          || !hOp2.getControls().empty()) {
+      auto hOp1 = dyn_cast_or_null<quake::HOp>(optional_hOp1);
+      if (!hOp1
+          || hOp1.getTargets().size() != 1
+          || !hOp1.getControls().empty()) {
         return;
       }
-      IRRewriter rewriter(hOp1->getContext());
+      IRRewriter rewriter(hOp2->getContext());
       rewriter.setInsertionPointAfter(hOp2);
       ValueRange targets = hOp1.getTargets();
       Location loc = hOp1.getLoc();

--- a/lib/Passes/Transforms/HXToZH.cpp
+++ b/lib/Passes/Transforms/HXToZH.cpp
@@ -30,24 +30,24 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto hOp = dyn_cast_or_null<quake::HOp>(op);
-      if (!hOp
-          || hOp.getTargets().size() != 1
-          || !hOp.getControls().empty()) {
-        return;
-      }
-      auto optional_xOp
-          = getNextOperationOnTarget(hOp, hOp.getTargets()[0]);
-      if (!optional_xOp) {
-        return;
-      }
-      auto xOp = dyn_cast_or_null<quake::XOp>(optional_xOp);
+      auto xOp = dyn_cast_or_null<quake::XOp>(op);
       if (!xOp
           || xOp.getTargets().size() != 1
           || !xOp.getControls().empty()) {
         return;
       }
-      IRRewriter rewriter(hOp->getContext());
+      auto optional_hOp
+          = getPreviousOperationOnTarget(xOp, xOp.getTargets()[0]);
+      if (!optional_hOp) {
+        return;
+      }
+      auto hOp = dyn_cast_or_null<quake::HOp>(optional_hOp);
+      if (!hOp
+          || hOp.getTargets().size() != 1
+          || !hOp.getControls().empty()) {
+        return;
+      }
+      IRRewriter rewriter(xOp->getContext());
       rewriter.setInsertionPointAfter(xOp);
       ValueRange targets = hOp.getTargets();
       Location loc = hOp.getLoc();

--- a/lib/Passes/Transforms/HYToYH.cpp
+++ b/lib/Passes/Transforms/HYToYH.cpp
@@ -29,23 +29,24 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto hOp = dyn_cast_or_null<quake::HOp>(op);
-      if (!hOp
-          || hOp.getTargets().size() != 1
-          || !hOp.getControls().empty()) {
-        return;
-      }
-      auto optional_yOp = getNextOperationOnTarget(hOp, hOp.getTargets()[0]);
-      if (!optional_yOp) {
-        return;
-      }
-      auto yOp = dyn_cast_or_null<quake::YOp>(optional_yOp);
+      auto yOp = dyn_cast_or_null<quake::YOp>(op);
       if (!yOp
           || yOp.getTargets().size() != 1
           || !yOp.getControls().empty()) {
         return;
       }
-      IRRewriter rewriter(hOp->getContext());
+      auto optional_hOp
+          = getPreviousOperationOnTarget(yOp, yOp.getTargets()[0]);
+      if (!optional_hOp) {
+        return;
+      }
+      auto hOp = dyn_cast_or_null<quake::HOp>(optional_hOp);
+      if (!hOp
+          || hOp.getTargets().size() != 1
+          || !hOp.getControls().empty()) {
+        return;
+      }
+      IRRewriter rewriter(yOp->getContext());
       rewriter.setInsertionPointAfter(yOp);
       ValueRange targets = hOp.getTargets();
       Location loc = hOp.getLoc();

--- a/lib/Passes/Transforms/HZHToX.cpp
+++ b/lib/Passes/Transforms/HZHToX.cpp
@@ -31,14 +31,14 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto hOp1 = dyn_cast_or_null<quake::HOp>(op);
-      if (!hOp1
-          || hOp1.getTargets().size() != 1
-          || !hOp1.getControls().empty()) {
+      auto hOp2 = dyn_cast_or_null<quake::HOp>(op);
+      if (!hOp2
+          || hOp2.getTargets().size() != 1
+          || !hOp2.getControls().empty()) {
         return;
       }
       auto optional_zOp
-          = getNextOperationOnTarget(hOp1, hOp1.getTargets()[0]);
+          = getPreviousOperationOnTarget(hOp2, hOp2.getTargets()[0]);
       if (!optional_zOp) {
         return;
       }
@@ -48,18 +48,18 @@ public:
           || !zOp.getControls().empty()) {
         return;
       }
-      auto optional_hOp2
-          = getNextOperationOnTarget(zOp, zOp.getTargets()[0]);
-      if (!optional_hOp2) {
+      auto optional_hOp1
+          = getPreviousOperationOnTarget(zOp, zOp.getTargets()[0]);
+      if (!optional_hOp1) {
         return;
       }
-      auto hOp2 = dyn_cast_or_null<quake::HOp>(optional_hOp2);
-      if (!hOp2
-          || hOp2.getTargets().size() != 1
-          || !hOp2.getControls().empty()) {
+      auto hOp1 = dyn_cast_or_null<quake::HOp>(optional_hOp1);
+      if (!hOp1
+          || hOp1.getTargets().size() != 1
+          || !hOp1.getControls().empty()) {
         return;
       }
-      IRRewriter rewriter(hOp1->getContext());
+      IRRewriter rewriter(hOp2->getContext());
       rewriter.setInsertionPointAfter(hOp2);
       ValueRange targets = hOp1.getTargets();
       Location loc = hOp1.getLoc();

--- a/lib/Passes/Transforms/HZToXH.cpp
+++ b/lib/Passes/Transforms/HZToXH.cpp
@@ -30,23 +30,24 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto hOp = dyn_cast_or_null<quake::HOp>(op);
-      if (!hOp
-          || hOp.getTargets().size() != 1
-          || !hOp.getControls().empty()) {
-        return;
-      }
-      auto optional_zOp = getNextOperationOnTarget(hOp, hOp.getTargets()[0]);
-      if (!optional_zOp) {
-        return;
-      }
-      auto zOp = dyn_cast_or_null<quake::ZOp>(optional_zOp);
+      auto zOp = dyn_cast_or_null<quake::ZOp>(op);
       if (!zOp
           || zOp.getTargets().size() != 1
           || !zOp.getControls().empty()) {
         return;
       }
-      IRRewriter rewriter(hOp->getContext());
+      auto optional_hOp
+          = getPreviousOperationOnTarget(zOp, zOp.getTargets()[0]);
+      if (!optional_hOp) {
+        return;
+      }
+      auto hOp = dyn_cast_or_null<quake::HOp>(optional_hOp);
+      if (!hOp
+          || hOp.getTargets().size() != 1
+          || !hOp.getControls().empty()) {
+        return;
+      }
+      IRRewriter rewriter(zOp->getContext());
       rewriter.setInsertionPointAfter(zOp);
       ValueRange targets = hOp.getTargets();
       Location loc = hOp.getLoc();

--- a/lib/Passes/Transforms/RxCxToCxRx.cpp
+++ b/lib/Passes/Transforms/RxCxToCxRx.cpp
@@ -31,25 +31,25 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto rxOp = dyn_cast_or_null<quake::RxOp>(op);
+      auto cxOp = dyn_cast_or_null<quake::XOp>(op);
+      if (!cxOp
+          || cxOp.getTargets().size() != 1
+          || cxOp.getControls().size() != 1) {
+        return;
+      }
+      auto optional_rxOp
+          = getPreviousOperationOnTarget(cxOp, cxOp.getTargets()[0]);
+      if (!optional_rxOp) {
+        return;
+      }
+      auto rxOp = dyn_cast_or_null<quake::RxOp>(optional_rxOp);
       if (!rxOp
           || rxOp.getTargets().size() != 1
           || !rxOp.getControls().empty()
           || rxOp.getParameters().size() != 1) {
         return;
       }
-      auto optional_cxOp
-          = getNextOperationOnTarget(rxOp, rxOp.getTargets()[0]);
-      if (!optional_cxOp) {
-        return;
-      }
-      auto cxOp = dyn_cast_or_null<quake::XOp>(optional_cxOp);
-      if (!cxOp
-          || cxOp.getTargets().size() != 1
-          || cxOp.getControls().size() != 1) {
-        return;
-      }
-      IRRewriter rewriter(rxOp->getContext());
+      IRRewriter rewriter(cxOp->getContext());
       rewriter.setInsertionPointAfter(cxOp);
       ValueRange targets = cxOp.getTargets();
       ValueRange controls = cxOp.getControls();

--- a/lib/Passes/Transforms/RxRxToRx.cpp
+++ b/lib/Passes/Transforms/RxRxToRx.cpp
@@ -30,23 +30,23 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto rxOp1 = dyn_cast_or_null<quake::RxOp>(op);
-      if (!rxOp1
-          || rxOp1.getTargets().size() != 1
-          || !rxOp1.getControls().empty()
-          || rxOp1.getParameters().size() != 1) {
-        return;
-      }
-      auto optional_rxOp2
-          = getNextOperationOnTarget(rxOp1, rxOp1.getTargets()[0]);
-      if (!optional_rxOp2) {
-        return;
-      }
-      auto rxOp2 = dyn_cast_or_null<quake::RxOp>(optional_rxOp2);
+      auto rxOp2 = dyn_cast_or_null<quake::RxOp>(op);
       if (!rxOp2
           || rxOp2.getTargets().size() != 1
           || !rxOp2.getControls().empty()
           || rxOp2.getParameters().size() != 1) {
+        return;
+      }
+      auto optional_rxOp1
+          = getPreviousOperationOnTarget(rxOp2, rxOp2.getTargets()[0]);
+      if (!optional_rxOp1) {
+        return;
+      }
+      auto rxOp1 = dyn_cast_or_null<quake::RxOp>(optional_rxOp1);
+      if (!rxOp1
+          || rxOp1.getTargets().size() != 1
+          || !rxOp1.getControls().empty()
+          || rxOp1.getParameters().size() != 1) {
         return;
       }
       auto rx1Params = getOperationParameters(rxOp1);
@@ -55,7 +55,7 @@ public:
         return;
       }
       double angle = rx1Params[0] + rx2Params[0];
-      IRRewriter rewriter(rxOp1->getContext());
+      IRRewriter rewriter(rxOp2->getContext());
       rewriter.setInsertionPointAfter(rxOp2);
       Location loc = rxOp1.getLoc();
       ValueRange targets = rxOp1.getTargets();

--- a/lib/Passes/Transforms/RyRyToRy.cpp
+++ b/lib/Passes/Transforms/RyRyToRy.cpp
@@ -28,23 +28,23 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto ryOp1 = dyn_cast_or_null<quake::RyOp>(op);
-      if (!ryOp1
-          || ryOp1.getTargets().size() != 1
-          || !ryOp1.getControls().empty()
-          || ryOp1.getParameters().size() != 1) {
-        return;
-      }
-      auto optional_ryOp2
-          = getNextOperationOnTarget(ryOp1, ryOp1.getTargets()[0]);
-      if (!optional_ryOp2) {
-        return;
-      }
-      auto ryOp2 = dyn_cast_or_null<quake::RyOp>(optional_ryOp2);
+      auto ryOp2 = dyn_cast_or_null<quake::RyOp>(op);
       if (!ryOp2
           || ryOp2.getTargets().size() != 1
           || !ryOp2.getControls().empty()
           || ryOp2.getParameters().size() != 1) {
+        return;
+      }
+      auto optional_ryOp1
+          = getPreviousOperationOnTarget(ryOp2, ryOp2.getTargets()[0]);
+      if (!optional_ryOp1) {
+        return;
+      }
+      auto ryOp1 = dyn_cast_or_null<quake::RyOp>(optional_ryOp1);
+      if (!ryOp1
+          || ryOp1.getTargets().size() != 1
+          || !ryOp1.getControls().empty()
+          || ryOp1.getParameters().size() != 1) {
         return;
       }
       auto ry1Params = getOperationParameters(ryOp1);
@@ -53,7 +53,7 @@ public:
         return;
       }
       double angle = ry1Params[0] + ry2Params[0];
-      IRRewriter rewriter(ryOp1->getContext());
+      IRRewriter rewriter(ryOp2->getContext());
       rewriter.setInsertionPointAfter(ryOp2);
       Location loc = ryOp1.getLoc();
       ValueRange targets = ryOp1.getTargets();

--- a/lib/Passes/Transforms/RzRzToRz.cpp
+++ b/lib/Passes/Transforms/RzRzToRz.cpp
@@ -30,23 +30,23 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto rzOp1 = dyn_cast_or_null<quake::RzOp>(op);
-      if (!rzOp1
-          || rzOp1.getTargets().size() != 1
-          || !rzOp1.getControls().empty()
-          || rzOp1.getParameters().size() != 1) {
-        return;
-      }
-      auto optional_rzOp2
-          = getNextOperationOnTarget(rzOp1, rzOp1.getTargets()[0]);
-      if (!optional_rzOp2) {
-        return;
-      }
-      auto rzOp2 = dyn_cast_or_null<quake::RzOp>(optional_rzOp2);
+      auto rzOp2 = dyn_cast_or_null<quake::RzOp>(op);
       if (!rzOp2
           || rzOp2.getTargets().size() != 1
           || !rzOp2.getControls().empty()
           || rzOp2.getParameters().size() != 1) {
+        return;
+      }
+      auto optional_rzOp1
+          = getPreviousOperationOnTarget(rzOp2, rzOp2.getTargets()[0]);
+      if (!optional_rzOp1) {
+        return;
+      }
+      auto rzOp1 = dyn_cast_or_null<quake::RzOp>(optional_rzOp1);
+      if (!rzOp1
+          || rzOp1.getTargets().size() != 1
+          || !rzOp1.getControls().empty()
+          || rzOp1.getParameters().size() != 1) {
         return;
       }
       auto rz1Params = getOperationParameters(rzOp1);
@@ -55,7 +55,7 @@ public:
         return;
       }
       double angle = rz1Params[0] + rz2Params[0];
-      IRRewriter rewriter(rzOp1->getContext());
+      IRRewriter rewriter(rzOp2->getContext());
       rewriter.setInsertionPointAfter(rzOp2);
       Location loc = rzOp1.getLoc();
       ValueRange targets = rzOp1.getTargets();

--- a/lib/Passes/Transforms/SSSToSdg.cpp
+++ b/lib/Passes/Transforms/SSSToSdg.cpp
@@ -31,15 +31,15 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto sOp1 = dyn_cast_or_null<quake::SOp>(op);
-      if (!sOp1
-          || sOp1.isAdj()
-          || sOp1.getTargets().size() != 1
-          || !sOp1.getControls().empty()) {
+      auto sOp3 = dyn_cast_or_null<quake::SOp>(op);
+      if (!sOp3
+          || sOp3.isAdj()
+          || sOp3.getTargets().size() != 1
+          || !sOp3.getControls().empty()) {
         return;
       }
       auto optional_sOp2
-          = getNextOperationOnTarget(sOp1, sOp1.getTargets()[0]);
+          = getPreviousOperationOnTarget(sOp3, sOp3.getTargets()[0]);
       if (!optional_sOp2) {
         return;
       }
@@ -50,19 +50,19 @@ public:
           || !sOp2.getControls().empty()) {
         return;
       }
-      auto optional_sOp3
-          = getNextOperationOnTarget(sOp2, sOp2.getTargets()[0]);
-      if (!optional_sOp3) {
+      auto optional_sOp1
+          = getPreviousOperationOnTarget(sOp2, sOp2.getTargets()[0]);
+      if (!optional_sOp1) {
         return;
       }
-      auto sOp3 = dyn_cast_or_null<quake::SOp>(optional_sOp3);
-      if (!sOp3
-          || sOp3.isAdj()
-          || sOp3.getTargets().size() != 1
-          || !sOp3.getControls().empty()) {
+      auto sOp1 = dyn_cast_or_null<quake::SOp>(optional_sOp1);
+      if (!sOp1
+          || sOp1.isAdj()
+          || sOp1.getTargets().size() != 1
+          || !sOp1.getControls().empty()) {
         return;
       }
-      IRRewriter rewriter(sOp1->getContext());
+      IRRewriter rewriter(sOp3->getContext());
       rewriter.setInsertionPointAfter(sOp1);
       Location loc = sOp1.getLoc();
       ValueRange targets = sOp1.getTargets();

--- a/lib/Passes/Transforms/SSToZ.cpp
+++ b/lib/Passes/Transforms/SSToZ.cpp
@@ -31,26 +31,26 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto sOp1 = dyn_cast_or_null<quake::SOp>(op);
-      if (!sOp1
-          || sOp1.isAdj()
-          || sOp1.getTargets().size() != 1
-          || !sOp1.getControls().empty()) {
-        return;
-      }
-      auto optional_sOp
-          = getNextOperationOnTarget(sOp1, sOp1.getTargets()[0]);
-      if (!optional_sOp) {
-        return;
-      }
-      auto sOp2 = dyn_cast_or_null<quake::SOp>(optional_sOp);
+      auto sOp2 = dyn_cast_or_null<quake::SOp>(op);
       if (!sOp2
           || sOp2.isAdj()
           || sOp2.getTargets().size() != 1
           || !sOp2.getControls().empty()) {
         return;
       }
-      IRRewriter rewriter(sOp1->getContext());
+      auto optional_sOp1
+          = getPreviousOperationOnTarget(sOp2, sOp2.getTargets()[0]);
+      if (!optional_sOp1) {
+        return;
+      }
+      auto sOp1 = dyn_cast_or_null<quake::SOp>(optional_sOp1);
+      if (!sOp1
+          || sOp1.isAdj()
+          || sOp1.getTargets().size() != 1
+          || !sOp1.getControls().empty()) {
+        return;
+      }
+      IRRewriter rewriter(sOp2->getContext());
       rewriter.setInsertionPointAfter(sOp2);
       Location loc = sOp1.getLoc();
       ValueRange targets = sOp1.getTargets();

--- a/lib/Passes/Transforms/SZToSdg.cpp
+++ b/lib/Passes/Transforms/SZToSdg.cpp
@@ -31,25 +31,25 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto sOp = dyn_cast_or_null<quake::SOp>(op);
+      auto zOp = dyn_cast_or_null<quake::ZOp>(op);
+      if (!zOp
+          || zOp.getTargets().size() != 1
+          || !zOp.getControls().empty()) {
+        return;
+      }
+      auto optional_sOp
+          = getPreviousOperationOnTarget(zOp, zOp.getTargets()[0]);
+      if (!optional_sOp) {
+        return;
+      }
+      auto sOp = dyn_cast_or_null<quake::SOp>(optional_sOp);
       if (!sOp
           || sOp.isAdj()
           || sOp.getTargets().size() != 1
           || !sOp.getControls().empty()) {
         return;
       }
-      auto optional_zOp
-          = getNextOperationOnTarget(sOp, sOp.getTargets()[0]);
-      if (!optional_zOp) {
-        return;
-      }
-      auto zOp = dyn_cast_or_null<quake::ZOp>(optional_zOp);
-      if (!zOp
-          || zOp.getTargets().size() != 1
-          || !zOp.getControls().empty()) {
-        return;
-      }
-      IRRewriter rewriter(sOp->getContext());
+      IRRewriter rewriter(zOp->getContext());
       rewriter.setInsertionPointAfter(zOp);
       Location loc = sOp.getLoc();
       ValueRange targets = sOp.getTargets();

--- a/lib/Passes/Transforms/SdgSdgSdgToS.cpp
+++ b/lib/Passes/Transforms/SdgSdgSdgToS.cpp
@@ -32,15 +32,15 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto sOp1 = dyn_cast_or_null<quake::SOp>(op);
-      if (!sOp1
-          || !sOp1.isAdj()
-          || sOp1.getTargets().size() != 1
-          || !sOp1.getControls().empty()) {
+      auto sOp3 = dyn_cast_or_null<quake::SOp>(op);
+      if (!sOp3
+          || !sOp3.isAdj()
+          || sOp3.getTargets().size() != 1
+          || !sOp3.getControls().empty()) {
         return;
       }
       auto optional_sOp2
-          = getNextOperationOnTarget(sOp1, sOp1.getTargets()[0]);
+          = getPreviousOperationOnTarget(sOp3, sOp3.getTargets()[0]);
       if (!optional_sOp2) {
         return;
       }
@@ -51,19 +51,19 @@ public:
           || !sOp2.getControls().empty()) {
         return;
       }
-      auto optional_sOp3
-          = getNextOperationOnTarget(sOp2, sOp2.getTargets()[0]);
-      if (!optional_sOp3) {
+      auto optional_sOp1
+          = getPreviousOperationOnTarget(sOp2, sOp2.getTargets()[0]);
+      if (!optional_sOp1) {
         return;
       }
-      auto sOp3 = dyn_cast_or_null<quake::SOp>(optional_sOp3);
-      if (!sOp3
-          || !sOp3.isAdj()
-          || sOp3.getTargets().size() != 1
-          || !sOp3.getControls().empty()) {
+      auto sOp1 = dyn_cast_or_null<quake::SOp>(optional_sOp1);
+      if (!sOp1
+          || !sOp1.isAdj()
+          || sOp1.getTargets().size() != 1
+          || !sOp1.getControls().empty()) {
         return;
       }
-      IRRewriter rewriter(sOp1->getContext());
+      IRRewriter rewriter(sOp3->getContext());
       rewriter.setInsertionPointAfter(sOp1);
       Location loc = sOp1.getLoc();
       ValueRange targets = sOp1.getTargets();

--- a/lib/Passes/Transforms/SdgSdgToZ.cpp
+++ b/lib/Passes/Transforms/SdgSdgToZ.cpp
@@ -30,26 +30,26 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto sOp1 = dyn_cast_or_null<quake::SOp>(op);
-      if (!sOp1
-          || !sOp1.isAdj()
-          || sOp1.getTargets().size() != 1
-          || !sOp1.getControls().empty()) {
-        return;
-      }
-      auto optional_sOp2
-          = getNextOperationOnTarget(sOp1, sOp1.getTargets()[0]);
-      if (!optional_sOp2) {
-        return;
-      }
-      auto sOp2 = dyn_cast_or_null<quake::SOp>(optional_sOp2);
+      auto sOp2 = dyn_cast_or_null<quake::SOp>(op);
       if (!sOp2
           || !sOp2.isAdj()
           || sOp2.getTargets().size() != 1
           || !sOp2.getControls().empty()) {
         return;
       }
-      IRRewriter rewriter(sOp1->getContext());
+      auto optional_sOp1
+          = getPreviousOperationOnTarget(sOp2, sOp2.getTargets()[0]);
+      if (!optional_sOp1) {
+        return;
+      }
+      auto sOp1 = dyn_cast_or_null<quake::SOp>(optional_sOp1);
+      if (!sOp1
+          || !sOp1.isAdj()
+          || sOp1.getTargets().size() != 1
+          || !sOp1.getControls().empty()) {
+        return;
+      }
+      IRRewriter rewriter(sOp2->getContext());
       rewriter.setInsertionPointAfter(sOp1);
       Location loc = sOp1.getLoc();
       ValueRange targets = sOp1.getTargets();

--- a/lib/Passes/Transforms/SdgZToS.cpp
+++ b/lib/Passes/Transforms/SdgZToS.cpp
@@ -31,25 +31,25 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto sOp = dyn_cast_or_null<quake::SOp>(op);
+      auto zOp = dyn_cast_or_null<quake::ZOp>(op);
+      if (!zOp
+          || zOp.getTargets().size() != 1
+          || !zOp.getControls().empty()) {
+        return;
+      }
+      auto optional_sOp
+          = getPreviousOperationOnTarget(zOp, zOp.getTargets()[0]);
+      if (!optional_sOp) {
+        return;
+      }
+      auto sOp = dyn_cast_or_null<quake::SOp>(optional_sOp);
       if (!sOp
           || !sOp.isAdj()
           || sOp.getTargets().size() != 1
           || !sOp.getControls().empty()) {
         return;
       }
-      auto optional_zOp
-          = getNextOperationOnTarget(sOp, sOp.getTargets()[0]);
-      if (!optional_zOp) {
-        return;
-      }
-      auto zOp = dyn_cast_or_null<quake::ZOp>(optional_zOp);
-      if (!zOp
-          || zOp.getTargets().size() != 1
-          || !zOp.getControls().empty()) {
-        return;
-      }
-      IRRewriter rewriter(sOp->getContext());
+      IRRewriter rewriter(zOp->getContext());
       rewriter.setInsertionPointAfter(zOp);
       Location loc = sOp.getLoc();
       ValueRange targets = sOp.getTargets();

--- a/lib/Passes/Transforms/TTToS.cpp
+++ b/lib/Passes/Transforms/TTToS.cpp
@@ -29,26 +29,26 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto tOp1 = dyn_cast_or_null<quake::TOp>(op);
-      if (!tOp1
-          || tOp1.isAdj()
-          || tOp1.getTargets().size() != 1
-          || !tOp1.getControls().empty()) {
-        return;
-      }
-      auto optional_tOp
-          = getNextOperationOnTarget(tOp1, tOp1.getTargets()[0]);
-      if (!optional_tOp) {
-        return;
-      }
-      auto tOp2 = dyn_cast_or_null<quake::TOp>(optional_tOp);
+      auto tOp2 = dyn_cast_or_null<quake::TOp>(op);
       if (!tOp2
           || tOp2.isAdj()
           || tOp2.getTargets().size() != 1
           || !tOp2.getControls().empty()) {
         return;
       }
-      IRRewriter rewriter(tOp1->getContext());
+      auto optional_tOp1
+          = getPreviousOperationOnTarget(tOp2, tOp2.getTargets()[0]);
+      if (!optional_tOp1) {
+        return;
+      }
+      auto tOp1 = dyn_cast_or_null<quake::TOp>(optional_tOp1);
+      if (!tOp1
+          || tOp1.isAdj()
+          || tOp1.getTargets().size() != 1
+          || !tOp1.getControls().empty()) {
+        return;
+      }
+      IRRewriter rewriter(tOp2->getContext());
       rewriter.setInsertionPointAfter(tOp2);
       Location loc = tOp1.getLoc();
       ValueRange targets = tOp1.getTargets();

--- a/lib/Passes/Transforms/XCxToCxX.cpp
+++ b/lib/Passes/Transforms/XCxToCxX.cpp
@@ -30,24 +30,24 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto xOp = dyn_cast_or_null<quake::XOp>(op);
-      if (!xOp
-          || xOp.getTargets().size() != 1
-          || !xOp.getControls().empty()) {
-        return;
-      }
-      auto optional_cxOp
-          = getNextOperationOnTarget(xOp, xOp.getTargets()[0]);
-      if (!optional_cxOp) {
-        return;
-      }
-      auto cxOp = dyn_cast_or_null<quake::XOp>(optional_cxOp);
+      auto cxOp = dyn_cast_or_null<quake::XOp>(op);
       if (!cxOp
           || cxOp.getTargets().size() != 1
           || cxOp.getControls().size() != 1) {
         return;
       }
-      IRRewriter rewriter(xOp->getContext());
+      auto optional_xOp
+          = getPreviousOperationOnTarget(cxOp, cxOp.getTargets()[0]);
+      if (!optional_xOp) {
+        return;
+      }
+      auto xOp = dyn_cast_or_null<quake::XOp>(optional_xOp);
+      if (!xOp
+          || xOp.getTargets().size() != 1
+          || !xOp.getControls().empty()) {
+        return;
+      }
+      IRRewriter rewriter(cxOp->getContext());
       rewriter.setInsertionPointAfter(cxOp);
       ValueRange targets = xOp.getTargets();
       ValueRange controls = cxOp.getControls();

--- a/lib/Passes/Transforms/XHToHZ.cpp
+++ b/lib/Passes/Transforms/XHToHZ.cpp
@@ -29,24 +29,24 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto xOp = dyn_cast_or_null<quake::XOp>(op);
-      if (!xOp
-          || xOp.getTargets().size() != 1
-          || !xOp.getControls().empty()) {
-        return;
-      }
-      auto optional_hOp
-          = getNextOperationOnTarget(xOp, xOp.getTargets()[0]);
-      if (!optional_hOp) {
-        return;
-      }
-      auto hOp = dyn_cast_or_null<quake::HOp>(optional_hOp);
+      auto hOp = dyn_cast_or_null<quake::HOp>(op);
       if (!hOp
           || hOp.getTargets().size() != 1
           || !hOp.getControls().empty()) {
         return;
       }
-      IRRewriter rewriter(xOp->getContext());
+      auto optional_xOp
+          = getPreviousOperationOnTarget(hOp, hOp.getTargets()[0]);
+      if (!optional_xOp) {
+        return;
+      }
+      auto xOp = dyn_cast_or_null<quake::XOp>(optional_xOp);
+      if (!xOp
+          || xOp.getTargets().size() != 1
+          || !xOp.getControls().empty()) {
+        return;
+      }
+      IRRewriter rewriter(hOp->getContext());
       rewriter.setInsertionPointAfter(hOp);
       ValueRange targets = xOp.getTargets();
       Location loc = xOp.getLoc();

--- a/lib/Passes/Transforms/XHZToH.cpp
+++ b/lib/Passes/Transforms/XHZToH.cpp
@@ -30,14 +30,14 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto xOp = dyn_cast_or_null<quake::XOp>(op);
-      if (!xOp
-          || xOp.getTargets().size() != 1
-          || !xOp.getControls().empty()) {
+      auto zOp = dyn_cast_or_null<quake::ZOp>(op);
+      if (!zOp
+          || zOp.getTargets().size() != 1
+          || !zOp.getControls().empty()) {
         return;
       }
       auto optional_hOp
-          = getNextOperationOnTarget(xOp, xOp.getTargets()[0]);
+          = getPreviousOperationOnTarget(zOp, zOp.getTargets()[0]);
       if (!optional_hOp) {
         return;
       }
@@ -47,18 +47,18 @@ public:
           || !hOp.getControls().empty()) {
         return;
       }
-      auto optional_zOp
-          = getNextOperationOnTarget(hOp, hOp.getTargets()[0]);
-      if (!optional_zOp) {
+      auto optional_xOp
+          = getPreviousOperationOnTarget(hOp, hOp.getTargets()[0]);
+      if (!optional_xOp) {
         return;
       }
-      auto zOp = dyn_cast_or_null<quake::ZOp>(optional_zOp);
-      if (!zOp
-          || zOp.getTargets().size() != 1
-          || !zOp.getControls().empty()) {
+      auto xOp = dyn_cast_or_null<quake::XOp>(optional_xOp);
+      if (!xOp
+          || xOp.getTargets().size() != 1
+          || !xOp.getControls().empty()) {
         return;
       }
-      IRRewriter rewriter(xOp->getContext());
+      IRRewriter rewriter(zOp->getContext());
       rewriter.setInsertionPointAfter(zOp);
       ValueRange targets = xOp.getTargets();
       Location loc = xOp.getLoc();

--- a/lib/Passes/Transforms/YHToHY.cpp
+++ b/lib/Passes/Transforms/YHToHY.cpp
@@ -28,24 +28,24 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto yOp = dyn_cast_or_null<quake::YOp>(op);
-      if (!yOp
-          || yOp.getTargets().size() != 1
-          || !yOp.getControls().empty()) {
-        return;
-      }
-      auto optional_hOp
-          = getNextOperationOnTarget(yOp, yOp.getTargets()[0]);
-      if (!optional_hOp) {
-        return;
-      }
-      auto hOp = dyn_cast_or_null<quake::HOp>(optional_hOp);
+      auto hOp = dyn_cast_or_null<quake::HOp>(op);
       if (!hOp
           || hOp.getTargets().size() != 1
           || !hOp.getControls().empty()) {
         return;
       }
-      IRRewriter rewriter(yOp->getContext());
+      auto optional_yOp
+          = getPreviousOperationOnTarget(hOp, hOp.getTargets()[0]);
+      if (!optional_yOp) {
+        return;
+      }
+      auto yOp = dyn_cast_or_null<quake::YOp>(optional_yOp);
+      if (!yOp
+          || yOp.getTargets().size() != 1
+          || !yOp.getControls().empty()) {
+        return;
+      }
+      IRRewriter rewriter(hOp->getContext());
       rewriter.setInsertionPointAfter(hOp);
       Value target = yOp.getTargets()[0];
       Location loc = yOp.getLoc();

--- a/lib/Passes/Transforms/ZCxToCxZ.cpp
+++ b/lib/Passes/Transforms/ZCxToCxZ.cpp
@@ -31,25 +31,25 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto zOp = dyn_cast_or_null<quake::ZOp>(op);
-      if (!zOp
-          || zOp.getTargets().size() != 1
-          || !zOp.getControls().empty()) {
-        return;
-      }
-      auto optional_cxOp
-          = getNextOperationOnTarget(zOp, zOp.getTargets()[0]);
-      if (!optional_cxOp) {
-        return;
-      }
-      auto cxOp = dyn_cast_or_null<quake::XOp>(optional_cxOp);
+      auto cxOp = dyn_cast_or_null<quake::XOp>(op);
       if (!cxOp
           || cxOp.getTargets().size() != 1
-          || cxOp.getControls().size() != 1
+          || cxOp.getControls().size() != 1) {
+        return;
+      }
+      auto optional_zOp
+          = getPreviousOperationOnTarget(cxOp, cxOp.getControls()[0]);
+      if (!optional_zOp) {
+        return;
+      }
+      auto zOp = dyn_cast_or_null<quake::ZOp>(optional_zOp);
+      if (!zOp
+          || zOp.getTargets().size() != 1
+          || !zOp.getControls().empty()
           || cxOp.getControls()[0] != zOp.getTargets()[0]) {
         return;
       }
-      IRRewriter rewriter(zOp->getContext());
+      IRRewriter rewriter(cxOp->getContext());
       rewriter.setInsertionPointAfter(cxOp);
       ValueRange targets = cxOp.getTargets();
       ValueRange controls = cxOp.getControls();

--- a/lib/Passes/Transforms/ZHToHX.cpp
+++ b/lib/Passes/Transforms/ZHToHX.cpp
@@ -30,24 +30,24 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto zOp = dyn_cast_or_null<quake::ZOp>(op);
-      if (!zOp
-          || zOp.getTargets().size() != 1
-          || !zOp.getControls().empty()) {
-        return;
-      }
-      auto optional_hOp
-          = getNextOperationOnTarget(zOp, zOp.getTargets()[0]);
-      if (!optional_hOp) {
-        return;
-      }
-      auto hOp = dyn_cast_or_null<quake::HOp>(optional_hOp);
+      auto hOp = dyn_cast_or_null<quake::HOp>(op);
       if (!hOp
           || hOp.getTargets().size() != 1
           || !hOp.getControls().empty()) {
         return;
       }
-      IRRewriter rewriter(zOp->getContext());
+      auto optional_zOp
+          = getPreviousOperationOnTarget(hOp, hOp.getTargets()[0]);
+      if (!optional_zOp) {
+        return;
+      }
+      auto zOp = dyn_cast_or_null<quake::ZOp>(optional_zOp);
+      if (!zOp
+          || zOp.getTargets().size() != 1
+          || !zOp.getControls().empty()) {
+        return;
+      }
+      IRRewriter rewriter(hOp->getContext());
       rewriter.setInsertionPointAfter(hOp);
       Value target = zOp.getTargets()[0];
       Location loc = zOp.getLoc();

--- a/lib/Passes/Transforms/ZHXToH.cpp
+++ b/lib/Passes/Transforms/ZHXToH.cpp
@@ -28,14 +28,14 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto zOp = dyn_cast_or_null<quake::ZOp>(op);
-      if (!zOp
-          || zOp.getTargets().size() != 1
-          || !zOp.getControls().empty()) {
+      auto xOp = dyn_cast_or_null<quake::XOp>(op);
+      if (!xOp
+          || xOp.getTargets().size() != 1
+          || !xOp.getControls().empty()) {
         return;
       }
       auto optional_hOp
-          = getNextOperationOnTarget(zOp, zOp.getTargets()[0]);
+          = getPreviousOperationOnTarget(xOp, xOp.getTargets()[0]);
       if (!optional_hOp) {
         return;
       }
@@ -45,18 +45,18 @@ public:
           || !hOp.getControls().empty()) {
         return;
       }
-      auto optional_xOp
-          = getNextOperationOnTarget(hOp, hOp.getTargets()[0]);
-      if (!optional_xOp) {
+      auto optional_zOp
+          = getPreviousOperationOnTarget(hOp, hOp.getTargets()[0]);
+      if (!optional_zOp) {
         return;
       }
-      auto xOp = dyn_cast_or_null<quake::XOp>(optional_xOp);
-      if (!xOp
-          || xOp.getTargets().size() != 1
-          || !xOp.getControls().empty()) {
+      auto zOp = dyn_cast_or_null<quake::ZOp>(optional_zOp);
+      if (!zOp
+          || zOp.getTargets().size() != 1
+          || !zOp.getControls().empty()) {
         return;
       }
-      IRRewriter rewriter(zOp->getContext());
+      IRRewriter rewriter(xOp->getContext());
       rewriter.setInsertionPointAfter(xOp);
       Value target = zOp.getTargets()[0];
       Location loc = zOp.getLoc();

--- a/lib/Passes/Transforms/ZSToSdg.cpp
+++ b/lib/Passes/Transforms/ZSToSdg.cpp
@@ -31,25 +31,25 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto zOp = dyn_cast_or_null<quake::ZOp>(op);
-      if (!zOp
-          || zOp.getTargets().size() != 1
-          || !zOp.getControls().empty()) {
-        return;
-      }
-      auto optional_sOp
-          = getNextOperationOnTarget(zOp, zOp.getTargets()[0]);
-      if (!optional_sOp) {
-        return;
-      }
-      auto sOp = dyn_cast_or_null<quake::SOp>(optional_sOp);
+      auto sOp = dyn_cast_or_null<quake::SOp>(op);
       if (!sOp
           || sOp.isAdj()
           || sOp.getTargets().size() != 1
           || !sOp.getControls().empty()) {
         return;
       }
-      IRRewriter rewriter(zOp->getContext());
+      auto optional_zOp
+          = getPreviousOperationOnTarget(sOp, sOp.getTargets()[0]);
+      if (!optional_zOp) {
+        return;
+      }
+      auto zOp = dyn_cast_or_null<quake::ZOp>(optional_zOp);
+      if (!zOp
+          || zOp.getTargets().size() != 1
+          || !zOp.getControls().empty()) {
+        return;
+      }
+      IRRewriter rewriter(sOp->getContext());
       rewriter.setInsertionPointAfter(sOp);
       Value target = zOp.getTargets()[0];
       Location loc = zOp.getLoc();

--- a/lib/Passes/Transforms/ZSdgToS.cpp
+++ b/lib/Passes/Transforms/ZSdgToS.cpp
@@ -29,25 +29,25 @@ public:
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
     kernel.walk([&](Operation *op) {
-      auto zOp = dyn_cast_or_null<quake::ZOp>(op);
-      if (!zOp
-          || zOp.getTargets().size() != 1
-          || !zOp.getControls().empty()) {
-        return;
-      }
-      auto optional_sOp
-          = getNextOperationOnTarget(zOp, zOp.getTargets()[0]);
-      if (!optional_sOp) {
-        return;
-      }
-      auto sOp = dyn_cast_or_null<quake::SOp>(optional_sOp);
+      auto sOp = dyn_cast_or_null<quake::SOp>(op);
       if (!sOp
           || !sOp.isAdj()
           || sOp.getTargets().size() != 1
           || !sOp.getControls().empty()) {
         return;
       }
-      IRRewriter rewriter(zOp->getContext());
+      auto optional_zOp
+          = getPreviousOperationOnTarget(sOp, sOp.getTargets()[0]);
+      if (!optional_zOp) {
+        return;
+      }
+      auto zOp = dyn_cast_or_null<quake::ZOp>(optional_zOp);
+      if (!zOp
+          || zOp.getTargets().size() != 1
+          || !zOp.getControls().empty()) {
+        return;
+      }
+      IRRewriter rewriter(sOp->getContext());
       rewriter.setInsertionPointAfter(sOp);
       Value target = zOp.getTargets()[0];
       Location loc = zOp.getLoc();


### PR DESCRIPTION
## Summary
- refactor all transform passes that used `getNextOperationOnTarget` to instead search backwards with `getPreviousOperationOnTarget`
- update each pass to inspect operations in the reversed order so the patterns still match

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd081675b88332a33abd19581adf2d