### PR TITLE
Guard commutation passes against control/target mismatches

### DIFF
--- a/lib/Passes/Transforms/CxRxToRxCx.cpp
+++ b/lib/Passes/Transforms/CxRxToRxCx.cpp
@@ -47,7 +47,8 @@ public:
       auto cxOp = dyn_cast_or_null<quake::XOp>(*optional_cxOp);
       if (!cxOp
           || cxOp.getTargets().size() != 1
-          || cxOp.getControls().size() != 1) {
+          || cxOp.getControls().size() != 1
+          || cxOp.getTargets()[0] != rxOp.getTargets()[0]) {
         return;
       }
       IRRewriter rewriter(rxOp->getContext());

--- a/lib/Passes/Transforms/CxXToXCx.cpp
+++ b/lib/Passes/Transforms/CxXToXCx.cpp
@@ -45,7 +45,8 @@ public:
       auto cxOp = dyn_cast_or_null<quake::XOp>(*optional_cxOp);
       if (!cxOp
           || cxOp.getTargets().size() != 1
-          || cxOp.getControls().size() != 1) {
+          || cxOp.getControls().size() != 1
+          || cxOp.getTargets()[0] != xOp.getTargets()[0]) {
         return;
       }
       IRRewriter rewriter(xOp->getContext());

--- a/lib/Passes/Transforms/CxZToZCx.cpp
+++ b/lib/Passes/Transforms/CxZToZCx.cpp
@@ -45,7 +45,8 @@ public:
       auto cxOp = dyn_cast_or_null<quake::XOp>(*optional_cxOp);
       if (!cxOp
           || cxOp.getTargets().size() != 1
-          || cxOp.getControls().size() != 1) {
+          || cxOp.getControls().size() != 1
+          || cxOp.getControls()[0] != zOp.getTargets()[0]) {
         return;
       }
       IRRewriter rewriter(zOp->getContext());


### PR DESCRIPTION
## Summary
- ensure the CxZToZCx rewrite only applies when the Z acts on the same control qubit as the preceding CNOT
- gate commutation in CxXToXCx and CxRxToRxCx now requires the matched qubit to be the CNOT target to avoid semantic changes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd0d3d359883329eb5275fadc7b80c