### PR TITLE
Add template stubs for remaining A2C agents

### DIFF
--- a/AI/src/Torch/A2C/a2c_db_conv_lsd.cpp
+++ b/AI/src/Torch/A2C/a2c_db_conv_lsd.cpp
@@ -1,0 +1,33 @@
+#include "Torch/A2C/a2c_agents.hpp"
+
+// Environment includes
+#include "Environment/environment.hpp"
+
+// Torch includes
+#include "Torch/parallel_environments.hpp"
+
+// Utils includes
+#include "Utils/circuit_utils.hpp"
+#include "Utils/passes_utils.hpp"
+
+// Standard library includes
+#include <sstream>
+#include <stdexcept>
+
+namespace ai_pass_selector {
+A2C_DB_CONV_LSD::A2C_DB_CONV_LSD(
+    int circuit_size_class, std::unordered_map<std::string, std::string> params)
+    : BaseA2CAgent(circuit_size_class, std::move(params)) {
+  unsigned int nr_input_values =
+      max_instructions * (max_qubits + NR_GATES + MAX_GATE_PARAMS);
+  (void)nr_input_values;
+  throw std::runtime_error("A2C_DB_CONV_LSD not implemented yet.");
+}
+
+std::string A2C_DB_CONV_LSD::agentName() const {
+  std::string size_class_str = CIRCUIT_SIZE_CLASS_TO_NAME.at(this->size_class);
+  std::ostringstream oss;
+  oss << "a2c-" << size_class_str << "-dbconvlsd";
+  return oss.str();
+}
+} // namespace ai_pass_selector

--- a/AI/src/Torch/A2C/a2c_db_conv_lsm.cpp
+++ b/AI/src/Torch/A2C/a2c_db_conv_lsm.cpp
@@ -1,0 +1,33 @@
+#include "Torch/A2C/a2c_agents.hpp"
+
+// Environment includes
+#include "Environment/environment.hpp"
+
+// Torch includes
+#include "Torch/parallel_environments.hpp"
+
+// Utils includes
+#include "Utils/circuit_utils.hpp"
+#include "Utils/passes_utils.hpp"
+
+// Standard library includes
+#include <sstream>
+#include <stdexcept>
+
+namespace ai_pass_selector {
+A2C_DB_CONV_LSM::A2C_DB_CONV_LSM(
+    int circuit_size_class, std::unordered_map<std::string, std::string> params)
+    : BaseA2CAgent(circuit_size_class, std::move(params)) {
+  unsigned int nr_input_values =
+      max_instructions * (max_qubits + NR_GATES + MAX_GATE_PARAMS);
+  (void)nr_input_values;
+  throw std::runtime_error("A2C_DB_CONV_LSM not implemented yet.");
+}
+
+std::string A2C_DB_CONV_LSM::agentName() const {
+  std::string size_class_str = CIRCUIT_SIZE_CLASS_TO_NAME.at(this->size_class);
+  std::ostringstream oss;
+  oss << "a2c-" << size_class_str << "-dbconvlsm";
+  return oss.str();
+}
+} // namespace ai_pass_selector

--- a/AI/src/Torch/A2C/a2c_db_fc_lsd.cpp
+++ b/AI/src/Torch/A2C/a2c_db_fc_lsd.cpp
@@ -1,0 +1,33 @@
+#include "Torch/A2C/a2c_agents.hpp"
+
+// Environment includes
+#include "Environment/environment.hpp"
+
+// Torch includes
+#include "Torch/parallel_environments.hpp"
+
+// Utils includes
+#include "Utils/circuit_utils.hpp"
+#include "Utils/passes_utils.hpp"
+
+// Standard library includes
+#include <sstream>
+#include <stdexcept>
+
+namespace ai_pass_selector {
+A2C_DB_FC_LSD::A2C_DB_FC_LSD(
+    int circuit_size_class, std::unordered_map<std::string, std::string> params)
+    : BaseA2CAgent(circuit_size_class, std::move(params)) {
+  unsigned int nr_input_values =
+      max_instructions * (max_qubits + NR_GATES + MAX_GATE_PARAMS);
+  (void)nr_input_values;
+  throw std::runtime_error("A2C_DB_FC_LSD not implemented yet.");
+}
+
+std::string A2C_DB_FC_LSD::agentName() const {
+  std::string size_class_str = CIRCUIT_SIZE_CLASS_TO_NAME.at(this->size_class);
+  std::ostringstream oss;
+  oss << "a2c-" << size_class_str << "-dbfclsd";
+  return oss.str();
+}
+} // namespace ai_pass_selector

--- a/AI/src/Torch/A2C/a2c_db_fc_lsm.cpp
+++ b/AI/src/Torch/A2C/a2c_db_fc_lsm.cpp
@@ -1,0 +1,33 @@
+#include "Torch/A2C/a2c_agents.hpp"
+
+// Environment includes
+#include "Environment/environment.hpp"
+
+// Torch includes
+#include "Torch/parallel_environments.hpp"
+
+// Utils includes
+#include "Utils/circuit_utils.hpp"
+#include "Utils/passes_utils.hpp"
+
+// Standard library includes
+#include <sstream>
+#include <stdexcept>
+
+namespace ai_pass_selector {
+A2C_DB_FC_LSM::A2C_DB_FC_LSM(
+    int circuit_size_class, std::unordered_map<std::string, std::string> params)
+    : BaseA2CAgent(circuit_size_class, std::move(params)) {
+  unsigned int nr_input_values =
+      max_instructions * (max_qubits + NR_GATES + MAX_GATE_PARAMS);
+  (void)nr_input_values;
+  throw std::runtime_error("A2C_DB_FC_LSM not implemented yet.");
+}
+
+std::string A2C_DB_FC_LSM::agentName() const {
+  std::string size_class_str = CIRCUIT_SIZE_CLASS_TO_NAME.at(this->size_class);
+  std::ostringstream oss;
+  oss << "a2c-" << size_class_str << "-dbfclsm";
+  return oss.str();
+}
+} // namespace ai_pass_selector

--- a/AI/src/Torch/A2C/a2c_ib_conv_lsd.cpp
+++ b/AI/src/Torch/A2C/a2c_ib_conv_lsd.cpp
@@ -1,0 +1,33 @@
+#include "Torch/A2C/a2c_agents.hpp"
+
+// Environment includes
+#include "Environment/environment.hpp"
+
+// Torch includes
+#include "Torch/parallel_environments.hpp"
+
+// Utils includes
+#include "Utils/circuit_utils.hpp"
+#include "Utils/passes_utils.hpp"
+
+// Standard library includes
+#include <sstream>
+#include <stdexcept>
+
+namespace ai_pass_selector {
+A2C_IB_CONV_LSD::A2C_IB_CONV_LSD(
+    int circuit_size_class, std::unordered_map<std::string, std::string> params)
+    : BaseA2CAgent(circuit_size_class, std::move(params)) {
+  unsigned int nr_input_values =
+      max_instructions * (max_qubits + NR_GATES + MAX_GATE_PARAMS);
+  (void)nr_input_values;
+  throw std::runtime_error("A2C_IB_CONV_LSD not implemented yet.");
+}
+
+std::string A2C_IB_CONV_LSD::agentName() const {
+  std::string size_class_str = CIRCUIT_SIZE_CLASS_TO_NAME.at(this->size_class);
+  std::ostringstream oss;
+  oss << "a2c-" << size_class_str << "-ibconvlsd";
+  return oss.str();
+}
+} // namespace ai_pass_selector

--- a/AI/src/Torch/A2C/a2c_ib_conv_lsm.cpp
+++ b/AI/src/Torch/A2C/a2c_ib_conv_lsm.cpp
@@ -1,0 +1,33 @@
+#include "Torch/A2C/a2c_agents.hpp"
+
+// Environment includes
+#include "Environment/environment.hpp"
+
+// Torch includes
+#include "Torch/parallel_environments.hpp"
+
+// Utils includes
+#include "Utils/circuit_utils.hpp"
+#include "Utils/passes_utils.hpp"
+
+// Standard library includes
+#include <sstream>
+#include <stdexcept>
+
+namespace ai_pass_selector {
+A2C_IB_CONV_LSM::A2C_IB_CONV_LSM(
+    int circuit_size_class, std::unordered_map<std::string, std::string> params)
+    : BaseA2CAgent(circuit_size_class, std::move(params)) {
+  unsigned int nr_input_values =
+      max_instructions * (max_qubits + NR_GATES + MAX_GATE_PARAMS);
+  (void)nr_input_values;
+  throw std::runtime_error("A2C_IB_CONV_LSM not implemented yet.");
+}
+
+std::string A2C_IB_CONV_LSM::agentName() const {
+  std::string size_class_str = CIRCUIT_SIZE_CLASS_TO_NAME.at(this->size_class);
+  std::ostringstream oss;
+  oss << "a2c-" << size_class_str << "-ibconvlsm";
+  return oss.str();
+}
+} // namespace ai_pass_selector


### PR DESCRIPTION
## Summary
- add placeholder source files for the six remaining A2C agent variants
- stub constructors throw not-implemented errors to make future implementation obvious
- provide agentName helpers that follow existing naming scheme

## Testing
- not run (templates only)


------
https://chatgpt.com/codex/tasks/task_e_68d2897c213c8332b3a5548a832b97dd