### PR TITLE
Replace AI constants with scoped enums

### DIFF
--- a/AI/include/Environment/quantum_circuit_environment.hpp
+++ b/AI/include/Environment/quantum_circuit_environment.hpp
@@ -43,12 +43,15 @@ namespace fs = std::filesystem;
 
 namespace ai_pass_selector {
 constexpr unsigned int MIN_NR_STEPS = 1u;
-constexpr int CIRCUIT_VALID = 0;
-constexpr int NO_CIRCUIT = 1;
-constexpr int INVALID_NR_QUBITS = 2;
-constexpr int INVALID_NR_GATES = 3;
-constexpr int INVALID_NR_ALLOCATIONS = 4;
-constexpr int AMBIGUOUS_MEASUREMENT = 5;
+
+enum class CircuitValidity : int {
+  Valid = 0,
+  NoCircuit = 1,
+  InvalidNrQubits = 2,
+  InvalidNrGates = 3,
+  InvalidNrAllocations = 4,
+  AmbiguousMeasurement = 5
+};
 
 class QuantumCircuitEnvironment {
   /// Attributes for circuit
@@ -114,7 +117,7 @@ public:
    *
    * @return
    */
-  int get_advanced_circuit_validity();
+  CircuitValidity get_advanced_circuit_validity();
 
   /**
    *

--- a/AI/include/Environment/random_quantum_circuit_generator.hpp
+++ b/AI/include/Environment/random_quantum_circuit_generator.hpp
@@ -14,9 +14,10 @@
 namespace fs = std::filesystem;
 
 namespace ai_pass_selector {
+enum class GateSymbol : int;
 struct GateSpec {
   // X,Y,Z,H,S,T,RX,RY,RZ,SWAP,R1,U2,U3,PHASED_RX
-  int baseGate;
+  GateSymbol baseGate;
   // Sdg/Tdg
   bool isAdj;
   // >=0 exact; -1 = not exact
@@ -82,7 +83,7 @@ sample_distinct_targets_and_controls(unsigned int nr_targets,
  * @param baseGate
  * @return
  */
-std::vector<float> makeAngles(int baseGate);
+std::vector<float> makeAngles(GateSymbol baseGate);
 
 /**
  *

--- a/AI/include/Environment/statistics_for_rqcg.hpp
+++ b/AI/include/Environment/statistics_for_rqcg.hpp
@@ -6,6 +6,7 @@
 
 // Standard library includes
 #include <filesystem>
+#include <cstddef>
 
 namespace fs = std::filesystem;
 
@@ -15,55 +16,68 @@ constexpr unsigned int GATES_WEIGHTS_SIZE = 37;
 constexpr unsigned int OPERATIONS_SUBSET_SIZE = 34;
 constexpr unsigned int CHOLESKY_PARAMS_SIZE = 11;
 /// Gates Indexes
-constexpr unsigned int X_INDEX = 0;
-constexpr unsigned int CX_INDEX = 1;
-constexpr unsigned int CCX_INDEX = 2;
-constexpr unsigned int C3plus_X_INDEX = 3;
-constexpr unsigned int Y_INDEX = 4;
-constexpr unsigned int controlled_Y_INDEX = 5;
-constexpr unsigned int Z_INDEX = 6;
-constexpr unsigned int controlled_Z_INDEX = 7;
-constexpr unsigned int H_INDEX = 8;
-constexpr unsigned int controlled_H_INDEX = 9;
-constexpr unsigned int S_INDEX = 10;
-constexpr unsigned int controlled_S_INDEX = 11;
-constexpr unsigned int SDG_INDEX = 12;
-constexpr unsigned int controlled_SDG_INDEX = 13;
-constexpr unsigned int T_INDEX = 14;
-constexpr unsigned int controlled_T_INDEX = 15;
-constexpr unsigned int TDG_INDEX = 16;
-constexpr unsigned int controlled_TDG_INDEX = 17;
-constexpr unsigned int RX_INDEX = 18;
-constexpr unsigned int controlled_RX_INDEX = 19;
-constexpr unsigned int RY_INDEX = 20;
-constexpr unsigned int controlled_RY_INDEX = 21;
-constexpr unsigned int RZ_INDEX = 22;
-constexpr unsigned int controlled_RZ_INDEX = 23;
-constexpr unsigned int SWAP_INDEX = 24;
-constexpr unsigned int controlled_SWAP_INDEX = 25;
-constexpr unsigned int R1_INDEX = 26;
-constexpr unsigned int controlled_R1_INDEX = 27;
-constexpr unsigned int U2_INDEX = 28;
-constexpr unsigned int controlled_U2_INDEX = 29;
-constexpr unsigned int U3_INDEX = 30;
-constexpr unsigned int controlled_U3_INDEX = 31;
-constexpr unsigned int PHASED_RX_INDEX = 32;
-constexpr unsigned int controlled_PHASED_RX_INDEX = 33;
-constexpr unsigned int MX_INDEX = 34;
-constexpr unsigned int MY_INDEX = 35;
-constexpr unsigned int MZ_INDEX = 36;
+enum class GateWeightIndex : unsigned int {
+  X = 0,
+  CX = 1,
+  CCX = 2,
+  C3PlusX = 3,
+  Y = 4,
+  ControlledY = 5,
+  Z = 6,
+  ControlledZ = 7,
+  H = 8,
+  ControlledH = 9,
+  S = 10,
+  ControlledS = 11,
+  SDG = 12,
+  ControlledSDG = 13,
+  T = 14,
+  ControlledT = 15,
+  TDG = 16,
+  ControlledTDG = 17,
+  RX = 18,
+  ControlledRX = 19,
+  RY = 20,
+  ControlledRY = 21,
+  RZ = 22,
+  ControlledRZ = 23,
+  SWAP = 24,
+  ControlledSWAP = 25,
+  R1 = 26,
+  ControlledR1 = 27,
+  U2 = 28,
+  ControlledU2 = 29,
+  U3 = 30,
+  ControlledU3 = 31,
+  PhasedRX = 32,
+  ControlledPhasedRX = 33,
+  MX = 34,
+  MY = 35,
+  MZ = 36
+};
+
 /// Cholseky Indexes
-constexpr unsigned int MEAN_QUBITS_INDEX = 0;
-constexpr unsigned int MEAN_GATES_INDEX = 1;
-constexpr unsigned int MEAN_OPERATIONS_INDEX = 2;
-constexpr unsigned int MEAN_MEASUREMENTS_INDEX = 3;
-constexpr unsigned int QUBITS_L11_INDEX = 4;
-constexpr unsigned int GATES_L21_INDEX = 5;
-constexpr unsigned int GATES_L22_INDEX = 6;
-constexpr unsigned int OPERATIONS_L21_INDEX = 7;
-constexpr unsigned int OPERATIONS_L22_INDEX = 8;
-constexpr unsigned int MEASUREMENTS_L21_INDEX = 9;
-constexpr unsigned int MEASUREMENTS_L22_INDEX = 10;
+enum class CholeskyParamIndex : unsigned int {
+  MeanQubits = 0,
+  MeanGates = 1,
+  MeanOperations = 2,
+  MeanMeasurements = 3,
+  QubitsL11 = 4,
+  GatesL21 = 5,
+  GatesL22 = 6,
+  OperationsL21 = 7,
+  OperationsL22 = 8,
+  MeasurementsL21 = 9,
+  MeasurementsL22 = 10
+};
+
+constexpr std::size_t to_index(GateWeightIndex index) {
+  return static_cast<std::size_t>(index);
+}
+
+constexpr std::size_t to_index(CholeskyParamIndex index) {
+  return static_cast<std::size_t>(index);
+}
 
 /**
  *

--- a/AI/include/NeuralNetworks/Agents/A3C/base_a3c_agent.hpp
+++ b/AI/include/NeuralNetworks/Agents/A3C/base_a3c_agent.hpp
@@ -14,13 +14,14 @@
 namespace fs = std::filesystem;
 
 namespace ai_pass_selector {
+enum class OptimizerType : int;
 
 class BaseA3CAgent : public BaseActorCritic {
 protected:
   /// Attributes on configuration
   unsigned int max_qubits = 0u;
-  int critic_optimizer_type = 0;
-  int actor_optimizer_type = 0;
+  OptimizerType critic_optimizer_type{};
+  OptimizerType actor_optimizer_type{};
   double critic_learning_rate = 0.0;
   double actor_learning_rate = 0.0;
   torch::Device device = torch::kCPU;

--- a/AI/include/NeuralNetworks/Agents/agent_utils.hpp
+++ b/AI/include/NeuralNetworks/Agents/agent_utils.hpp
@@ -10,51 +10,70 @@
 // Standard Library includes
 #include <filesystem>
 #include <memory>
+#include <unordered_map>
 
 namespace fs = std::filesystem;
 
 using namespace mqss::opt;
 
 namespace ai_pass_selector {
+enum class AgentClass : int {
+  A3C = 1,
+  SAC = 2,
+  ACKTR = 3,
+  ACER = 4,
+  PPO = 5,
+  CROSSQ = 6
+};
+
+enum class OptimizerType : int {
+  Adagrad = 1,
+  Adam = 2,
+  AdamW = 3,
+  LBFGS = 4,
+  RMSProp = 5,
+  SGD = 6
+};
+
+struct EnumClassHash {
+  template <typename T>
+  std::size_t operator()(T value) const noexcept {
+    return static_cast<std::size_t>(value);
+  }
+};
+
 struct AgentAttributes {
-  int agent_class;
+  AgentClass agent_class;
   unsigned int max_qubits;
   std::string extras;
 };
 
-/// Agent classes
-constexpr int A3C = 1;
-constexpr int SAC = 2;
-constexpr int ACKTR = 3;
-constexpr int ACER = 4;
-constexpr int PPO = 5;
-constexpr int CROSSQ = 6;
+const std::unordered_map<std::string, AgentClass> AGENT_NAME_TO_CLASS = {
+    {"a3c", AgentClass::A3C},   {"sac", AgentClass::SAC},
+    {"acktr", AgentClass::ACKTR}, {"acer", AgentClass::ACER},
+    {"ppo", AgentClass::PPO},   {"crossq", AgentClass::CROSSQ}};
 
-const std::unordered_map<std::string, int> AGENT_NAME_TO_CLASS = {
-    {"a3c", A3C},   {"sac", SAC}, {"acktr", ACKTR},
-    {"acer", ACER}, {"ppo", PPO}, {"crossq", CROSSQ}};
-
-const std::unordered_map<int, std::string> AGENT_CLASS_TO_NAME = {
-    {A3C, "a3c"},   {SAC, "sac"}, {ACKTR, "acktr"},
-    {ACER, "acer"}, {PPO, "ppo"}, {CROSSQ, "crossq"}};
+const std::unordered_map<AgentClass, std::string, EnumClassHash>
+    AGENT_CLASS_TO_NAME = {{AgentClass::A3C, "a3c"},
+                           {AgentClass::SAC, "sac"},
+                           {AgentClass::ACKTR, "acktr"},
+                           {AgentClass::ACER, "acer"},
+                           {AgentClass::PPO, "ppo"},
+                           {AgentClass::CROSSQ, "crossq"}};
 
 /// Optimizers
-constexpr int OPTIMIZER_ADAGRAD = 1;
-constexpr int OPTIMIZER_ADAM = 2;
-constexpr int OPTIMIZER_ADAMW = 3;
-constexpr int OPTIMIZER_LBFGS = 4;
-constexpr int OPTIMIZER_RMSPROP = 5;
-constexpr int OPTIMIZER_SGD = 6;
+const std::unordered_map<std::string, OptimizerType> OPTIMIZER_NAME_TO_TYPE = {
+    {"adagrad", OptimizerType::Adagrad}, {"adam", OptimizerType::Adam},
+    {"adamw", OptimizerType::AdamW},     {"lbfgs", OptimizerType::LBFGS},
+    {"rmsprop", OptimizerType::RMSProp}, {"sgd", OptimizerType::SGD}};
 
-const std::unordered_map<std::string, int> OPTIMIZER_NAME_TO_TYPE = {
-    {"adagrad", OPTIMIZER_ADAGRAD}, {"adam", OPTIMIZER_ADAM},
-    {"adamw", OPTIMIZER_ADAMW},     {"lbfgs", OPTIMIZER_LBFGS},
-    {"rmsprop", OPTIMIZER_RMSPROP}, {"sgd", OPTIMIZER_SGD}};
-
-const std::unordered_map<int, std::string> OPTIMIZER_TYPE_TO_NAME = {
-    {OPTIMIZER_ADAGRAD, "adagrad"}, {OPTIMIZER_ADAM, "adam"},
-    {OPTIMIZER_ADAMW, "adamw"},     {OPTIMIZER_LBFGS, "lbfgs"},
-    {OPTIMIZER_RMSPROP, "rmsprop"}, {OPTIMIZER_SGD, "sgd"}};
+const std::unordered_map<OptimizerType, std::string, EnumClassHash>
+    OPTIMIZER_TYPE_TO_NAME = {{OptimizerType::Adagrad, "adagrad"},
+                              {OptimizerType::Adam, "adam"},
+                              {OptimizerType::AdamW, "adamw"},
+                              {OptimizerType::LBFGS, "lbfgs"},
+                              {OptimizerType::RMSProp, "rmsprop"},
+                              {OptimizerType::SGD, "sgd"}};
 
 /**
  *
@@ -71,8 +90,8 @@ AgentAttributes parseAgentName(const std::string &agent_name);
  * @return
  */
 std::unique_ptr<torch::optim::Optimizer>
-makeOptimizer(int optimizerType, const torch::nn::Sequential &agentModel,
-              double learningRate);
+makeOptimizer(OptimizerType optimizerType,
+              const torch::nn::Sequential &agentModel, double learningRate);
 
 /**
  *

--- a/AI/include/NeuralNetworks/Agents/base_actor_critic.hpp
+++ b/AI/include/NeuralNetworks/Agents/base_actor_critic.hpp
@@ -17,12 +17,14 @@ namespace fs = std::filesystem;
 
 namespace ai_pass_selector {
 
+enum class OptimizerType : int;
+
 class BaseActorCritic : public torch::nn::Module {
 protected:
   /// Attributes on configuration
   unsigned int max_qubits = 0u;
-  int actor_optimizer_type = 0;
-  int critic_optimizer_type = 0;
+  OptimizerType actor_optimizer_type{};
+  OptimizerType critic_optimizer_type{};
   double actor_learning_rate = 0.0;
   double critic_learning_rate = 0.0;
   torch::Device device = torch::kCPU;

--- a/AI/include/Utils/tensor_utils.hpp
+++ b/AI/include/Utils/tensor_utils.hpp
@@ -19,23 +19,30 @@ using mlir::ValueRange;
 using mlir::func::FuncOp;
 
 namespace ai_pass_selector {
-constexpr int X = GATE_INDEX("x"sv);
-constexpr int Y = GATE_INDEX("y"sv);
-constexpr int Z = GATE_INDEX("z"sv);
-constexpr int H = GATE_INDEX("h"sv);
-constexpr int S = GATE_INDEX("s"sv);
-constexpr int T = GATE_INDEX("t"sv);
-constexpr int RX = GATE_INDEX("rx"sv);
-constexpr int RY = GATE_INDEX("ry"sv);
-constexpr int RZ = GATE_INDEX("rz"sv);
-constexpr int SWAP = GATE_INDEX("swap"sv);
-constexpr int R1 = GATE_INDEX("r1"sv);
-constexpr int U2 = GATE_INDEX("u2"sv);
-constexpr int U3 = GATE_INDEX("u3"sv);
-constexpr int PHASED_RX = GATE_INDEX("phased_rx"sv);
-constexpr int MX = GATE_INDEX("mx"sv);
-constexpr int MY = GATE_INDEX("my"sv);
-constexpr int MZ = GATE_INDEX("mz"sv);
+
+enum class GateSymbol : int {
+  X = GATE_INDEX("x"sv),
+  Y = GATE_INDEX("y"sv),
+  Z = GATE_INDEX("z"sv),
+  H = GATE_INDEX("h"sv),
+  S = GATE_INDEX("s"sv),
+  T = GATE_INDEX("t"sv),
+  RX = GATE_INDEX("rx"sv),
+  RY = GATE_INDEX("ry"sv),
+  RZ = GATE_INDEX("rz"sv),
+  SWAP = GATE_INDEX("swap"sv),
+  R1 = GATE_INDEX("r1"sv),
+  U2 = GATE_INDEX("u2"sv),
+  U3 = GATE_INDEX("u3"sv),
+  PHASED_RX = GATE_INDEX("phased_rx"sv),
+  MX = GATE_INDEX("mx"sv),
+  MY = GATE_INDEX("my"sv),
+  MZ = GATE_INDEX("mz"sv)
+};
+
+constexpr int to_gate_index(GateSymbol symbol) {
+  return static_cast<int>(symbol);
+}
 
 struct RebuildSetup {
   std::unique_ptr<MLIRContext> ctxOwner;
@@ -104,7 +111,7 @@ std::vector<Value> anglesToValues(OpBuilder &builder, Location loc,
  * @param gateIndex
  * @param targets
  */
-static void insertMeasurements(RebuildSetup &rebuildSetup, int gateIndex,
+static void insertMeasurements(RebuildSetup &rebuildSetup, GateSymbol gate,
                                ValueRange targets);
 
 /**
@@ -116,7 +123,7 @@ static void insertMeasurements(RebuildSetup &rebuildSetup, int gateIndex,
  * @param angles
  * @param isAdj
  */
-void insertGate(RebuildSetup &rebuildSetup, int gateIndex,
+void insertGate(RebuildSetup &rebuildSetup, GateSymbol gate,
                 const std::vector<int> &targetIndexes,
                 const std::vector<int> &controlIndexes = {},
                 const std::vector<float> &angles = {}, bool isAdj = false);

--- a/AI/src/Environment/quantum_circuit_environment.cpp
+++ b/AI/src/Environment/quantum_circuit_environment.cpp
@@ -114,28 +114,28 @@ bool QuantumCircuitEnvironment::register_quantum_circuit(
     return false;
   }
   this->circuit = QuantumCircuit(circuit_path);
-  int circuit_validity = this->get_advanced_circuit_validity();
+  CircuitValidity circuit_validity = this->get_advanced_circuit_validity();
   switch (circuit_validity) {
-  case CIRCUIT_VALID:
+  case CircuitValidity::Valid:
     break;
-  case NO_CIRCUIT:
+  case CircuitValidity::NoCircuit:
     std::cerr << "No circuit provided to the environment." << std::endl;
     break;
-  case INVALID_NR_QUBITS:
+  case CircuitValidity::InvalidNrQubits:
     std::cerr << "Passed circuit has invalid nr qubits." << std::endl;
     break;
-  case INVALID_NR_GATES:
+  case CircuitValidity::InvalidNrGates:
     std::cerr << "Passed circuit has invalid nr gates." << std::endl;
     break;
-  case INVALID_NR_ALLOCATIONS:
+  case CircuitValidity::InvalidNrAllocations:
     std::cerr << "Passed circuit has invalid allocations." << std::endl;
     break;
-  case AMBIGUOUS_MEASUREMENT:
+  case CircuitValidity::AmbiguousMeasurement:
     std::cerr << "Passed circuit has ambiguous measurements." << std::endl;
     break;
   default:;
   }
-  if (circuit_validity != CIRCUIT_VALID) {
+  if (circuit_validity != CircuitValidity::Valid) {
     this->clear(/*hard=*/false);
     return false;
   }
@@ -173,9 +173,9 @@ void QuantumCircuitEnvironment::register_randomizer_params(
   this->gates_weights = gates_weights;
 }
 
-int QuantumCircuitEnvironment::get_advanced_circuit_validity() {
+CircuitValidity QuantumCircuitEnvironment::get_advanced_circuit_validity() {
   if (!this->circuit.exists()) {
-    return NO_CIRCUIT;
+    return CircuitValidity::NoCircuit;
   }
   unsigned int nr_qubits = 0u;
   unsigned int nr_gates = 0u;
@@ -257,16 +257,16 @@ int QuantumCircuitEnvironment::get_advanced_circuit_validity() {
     return mlir::WalkResult::advance();
   });
   if (nr_qubits < GLOBAL_MIN_NR_QUBITS || nr_qubits > max_qubits) {
-    return INVALID_NR_QUBITS;
+    return CircuitValidity::InvalidNrQubits;
   }
   if (nr_gates < GLOBAL_MIN_NR_GATES) {
-    return INVALID_NR_GATES;
+    return CircuitValidity::InvalidNrGates;
   }
   if (nr_allocations != 1) {
-    return INVALID_NR_ALLOCATIONS;
+    return CircuitValidity::InvalidNrAllocations;
   }
   if (ambiguous_measurement) {
-    return AMBIGUOUS_MEASUREMENT;
+    return CircuitValidity::AmbiguousMeasurement;
   }
   if (nr_qubits != this->circuit.get_nr_qubits() ||
       nr_gates != this->circuit.get_nr_gates()) {
@@ -278,7 +278,7 @@ int QuantumCircuitEnvironment::get_advanced_circuit_validity() {
         "Mismatch in algorithms computing nr_circuits and nr_gates between "
         "QuantumCircuit and QuantumCircuitEnvironment.");
   }
-  return CIRCUIT_VALID;
+  return CircuitValidity::Valid;
 }
 
 std::unordered_map<std::string, unsigned int>

--- a/AI/src/Environment/random_quantum_circuit_generator.cpp
+++ b/AI/src/Environment/random_quantum_circuit_generator.cpp
@@ -25,6 +25,8 @@ using llvm::isa;
 #include <filesystem>
 #include <iostream>
 #include <random>
+#include <stdexcept>
+#include <string>
 #include <unordered_set>
 
 namespace fs = std::filesystem;
@@ -36,85 +38,85 @@ static GateSpec gateSpecFromIndex(unsigned int idx) {
   if (idx >= GATES_WEIGHTS_SIZE) {
     llvm::report_fatal_error("gateSpecFromIndex: out of range");
   }
-  switch (idx) {
-  case X_INDEX:
-    return {X, false, 0, 0, false, false};
-  case CX_INDEX:
-    return {X, false, 1, 0, false, false};
-  case CCX_INDEX:
-    return {X, false, 2, 0, false, false};
-  case C3plus_X_INDEX:
-    return {X, false, -1, 3, true, false};
-  case Y_INDEX:
-    return {Y, false, 0, 0, false, false};
-  case controlled_Y_INDEX:
-    return {Y, false, -1, 1, true, false};
-  case Z_INDEX:
-    return {Z, false, 0, 0, false, false};
-  case controlled_Z_INDEX:
-    return {Z, false, -1, 1, true, false};
-  case H_INDEX:
-    return {H, false, 0, 0, false, false};
-  case controlled_H_INDEX:
-    return {H, false, -1, 1, true, false};
-  case S_INDEX:
-    return {S, false, 0, 0, false, false};
-  case controlled_S_INDEX:
-    return {S, false, -1, 1, true, false};
-  case SDG_INDEX:
-    return {S, true, 0, 0, false, false};
-  case controlled_SDG_INDEX:
-    return {S, true, -1, 1, true, false};
-  case T_INDEX:
-    return {T, false, 0, 0, false, false};
-  case controlled_T_INDEX:
-    return {T, false, -1, 1, true, false};
-  case TDG_INDEX:
-    return {T, true, 0, 0, false, false};
-  case controlled_TDG_INDEX:
-    return {T, true, -1, 1, true, false};
-  case RX_INDEX:
-    return {RX, false, 0, 0, false, false};
-  case controlled_RX_INDEX:
-    return {RX, false, -1, 1, true, false};
-  case RY_INDEX:
-    return {RY, false, 0, 0, false, false};
-  case controlled_RY_INDEX:
-    return {RY, false, -1, 1, true, false};
-  case RZ_INDEX:
-    return {RZ, false, 0, 0, false, false};
-  case controlled_RZ_INDEX:
-    return {RZ, false, -1, 1, true, false};
-  case SWAP_INDEX:
-    return {SWAP, false, 0, 0, false, true};
-  case controlled_SWAP_INDEX:
-    return {SWAP, false, -1, 1, true, true};
-  case R1_INDEX:
-    return {R1, false, 0, 0, false, false};
-  case controlled_R1_INDEX:
-    return {R1, false, -1, 1, true, false};
-  case U2_INDEX:
-    return {U2, false, 0, 0, false, false};
-  case controlled_U2_INDEX:
-    return {U2, false, -1, 1, true, false};
-  case U3_INDEX:
-    return {U3, false, 0, 0, false, false};
-  case controlled_U3_INDEX:
-    return {U3, false, -1, 1, true, false};
-  case PHASED_RX_INDEX:
-    return {PHASED_RX, false, 0, 0, false, false};
-  case controlled_PHASED_RX_INDEX:
-    return {PHASED_RX, false, -1, 1, true, false};
-  case MX_INDEX:
-    return {MX, false, 0, 0, false, false};
-  case MY_INDEX:
-    return {MY, false, 0, 0, false, false};
-  case MZ_INDEX:
-    return {MZ, false, 0, 0, false, false};
+  switch (static_cast<GateWeightIndex>(idx)) {
+  case GateWeightIndex::X:
+    return {GateSymbol::X, false, 0, 0, false, false};
+  case GateWeightIndex::CX:
+    return {GateSymbol::X, false, 1, 0, false, false};
+  case GateWeightIndex::CCX:
+    return {GateSymbol::X, false, 2, 0, false, false};
+  case GateWeightIndex::C3PlusX:
+    return {GateSymbol::X, false, -1, 3, true, false};
+  case GateWeightIndex::Y:
+    return {GateSymbol::Y, false, 0, 0, false, false};
+  case GateWeightIndex::ControlledY:
+    return {GateSymbol::Y, false, -1, 1, true, false};
+  case GateWeightIndex::Z:
+    return {GateSymbol::Z, false, 0, 0, false, false};
+  case GateWeightIndex::ControlledZ:
+    return {GateSymbol::Z, false, -1, 1, true, false};
+  case GateWeightIndex::H:
+    return {GateSymbol::H, false, 0, 0, false, false};
+  case GateWeightIndex::ControlledH:
+    return {GateSymbol::H, false, -1, 1, true, false};
+  case GateWeightIndex::S:
+    return {GateSymbol::S, false, 0, 0, false, false};
+  case GateWeightIndex::ControlledS:
+    return {GateSymbol::S, false, -1, 1, true, false};
+  case GateWeightIndex::SDG:
+    return {GateSymbol::S, true, 0, 0, false, false};
+  case GateWeightIndex::ControlledSDG:
+    return {GateSymbol::S, true, -1, 1, true, false};
+  case GateWeightIndex::T:
+    return {GateSymbol::T, false, 0, 0, false, false};
+  case GateWeightIndex::ControlledT:
+    return {GateSymbol::T, false, -1, 1, true, false};
+  case GateWeightIndex::TDG:
+    return {GateSymbol::T, true, 0, 0, false, false};
+  case GateWeightIndex::ControlledTDG:
+    return {GateSymbol::T, true, -1, 1, true, false};
+  case GateWeightIndex::RX:
+    return {GateSymbol::RX, false, 0, 0, false, false};
+  case GateWeightIndex::ControlledRX:
+    return {GateSymbol::RX, false, -1, 1, true, false};
+  case GateWeightIndex::RY:
+    return {GateSymbol::RY, false, 0, 0, false, false};
+  case GateWeightIndex::ControlledRY:
+    return {GateSymbol::RY, false, -1, 1, true, false};
+  case GateWeightIndex::RZ:
+    return {GateSymbol::RZ, false, 0, 0, false, false};
+  case GateWeightIndex::ControlledRZ:
+    return {GateSymbol::RZ, false, -1, 1, true, false};
+  case GateWeightIndex::SWAP:
+    return {GateSymbol::SWAP, false, 0, 0, false, true};
+  case GateWeightIndex::ControlledSWAP:
+    return {GateSymbol::SWAP, false, -1, 1, true, true};
+  case GateWeightIndex::R1:
+    return {GateSymbol::R1, false, 0, 0, false, false};
+  case GateWeightIndex::ControlledR1:
+    return {GateSymbol::R1, false, -1, 1, true, false};
+  case GateWeightIndex::U2:
+    return {GateSymbol::U2, false, 0, 0, false, false};
+  case GateWeightIndex::ControlledU2:
+    return {GateSymbol::U2, false, -1, 1, true, false};
+  case GateWeightIndex::U3:
+    return {GateSymbol::U3, false, 0, 0, false, false};
+  case GateWeightIndex::ControlledU3:
+    return {GateSymbol::U3, false, -1, 1, true, false};
+  case GateWeightIndex::PhasedRX:
+    return {GateSymbol::PHASED_RX, false, 0, 0, false, false};
+  case GateWeightIndex::ControlledPhasedRX:
+    return {GateSymbol::PHASED_RX, false, -1, 1, true, false};
+  case GateWeightIndex::MX:
+    return {GateSymbol::MX, false, 0, 0, false, false};
+  case GateWeightIndex::MY:
+    return {GateSymbol::MY, false, 0, 0, false, false};
+  case GateWeightIndex::MZ:
+    return {GateSymbol::MZ, false, 0, 0, false, false};
   default:
-    std::cerr << "gateSpecFromIndex: unknown index " << idx << std::endl;
+    throw std::logic_error("gateSpecFromIndex: unknown index " +
+                           std::to_string(idx));
   }
-  return {0, false, 0, 0, false, false};
 }
 
 std::pair<std::vector<int>, std::vector<int>>
@@ -162,18 +164,18 @@ sample_distinct_targets_and_controls(unsigned int nr_targets,
   return {targets, controls};
 }
 
-std::vector<float> makeAngles(int baseGate) {
+std::vector<float> makeAngles(GateSymbol baseGate) {
   switch (baseGate) {
-  case RX:
-  case RY:
-  case RZ:
-  case R1:
+  case GateSymbol::RX:
+  case GateSymbol::RY:
+  case GateSymbol::RZ:
+  case GateSymbol::R1:
     return {randomAngle()};
-  case U2:
+  case GateSymbol::U2:
     return {randomAngle(), randomAngle()};
-  case U3:
+  case GateSymbol::U3:
     return {randomAngle(), randomAngle(), randomAngle()};
-  case PHASED_RX:
+  case GateSymbol::PHASED_RX:
     return {randomAngle(), randomAngle()};
   default:
     return {};
@@ -353,7 +355,7 @@ QuantumCircuit random_quantum_circuit_from_embedded_statistics(
       std::vector<float> angles = makeAngles(baseGate);
       insertGate(buildSetup, baseGate, targets, controls, angles, isAdj);
 
-      if (baseGate == MX || baseGate == MY || baseGate == MZ) {
+      if (baseGate == GateSymbol::MX || baseGate == GateSymbol::MY || baseGate == GateSymbol::MZ) {
         // Measurement by default do not have controls so there is no need to
         // consider controls as possibly involved qubits.
         for (int qubit : targets) {
@@ -383,12 +385,12 @@ QuantumCircuit random_quantum_circuit_from_embedded_statistics(
     std::vector targets{qubit_idx};
     if (const unsigned int idx =
             measurements_distribution(qc_rng()) + OPERATIONS_SUBSET_SIZE;
-        idx == MX_INDEX) {
-      insertGate(buildSetup, MX, targets);
-    } else if (idx == MY_INDEX) {
-      insertGate(buildSetup, MY, targets);
-    } else if (idx == MZ_INDEX) {
-      insertGate(buildSetup, MZ, targets);
+        static_cast<GateWeightIndex>(idx) == GateWeightIndex::MX) {
+      insertGate(buildSetup, GateSymbol::MX, targets);
+    } else if (static_cast<GateWeightIndex>(idx) == GateWeightIndex::MY) {
+      insertGate(buildSetup, GateSymbol::MY, targets);
+    } else if (static_cast<GateWeightIndex>(idx) == GateWeightIndex::MZ) {
+      insertGate(buildSetup, GateSymbol::MZ, targets);
     } else {
       throw std::runtime_error("Unknown measurement index " +
                                std::to_string(idx));
@@ -433,84 +435,105 @@ QuantumCircuit random_quantum_circuit_from_yaml_statistics(
   };
 
   std::array<double, CHOLESKY_PARAMS_SIZE> cholesky_params = {};
-  cholesky_params[MEAN_QUBITS_INDEX] =
+  cholesky_params[to_index(CholeskyParamIndex::MeanQubits)] =
       get_double(yaml_qubits_cholesky_params, "mean_qubits");
-  cholesky_params[MEAN_GATES_INDEX] =
+  cholesky_params[to_index(CholeskyParamIndex::MeanGates)] =
       get_double(yaml_qubits_cholesky_params, "mean_gates");
-  cholesky_params[MEAN_OPERATIONS_INDEX] =
+  cholesky_params[to_index(CholeskyParamIndex::MeanOperations)] =
       get_double(yaml_qubits_cholesky_params, "mean_operations");
-  cholesky_params[MEAN_MEASUREMENTS_INDEX] =
+  cholesky_params[to_index(CholeskyParamIndex::MeanMeasurements)] =
       get_double(yaml_qubits_cholesky_params, "mean_measurements");
-  cholesky_params[QUBITS_L11_INDEX] =
+  cholesky_params[to_index(CholeskyParamIndex::QubitsL11)] =
       get_double(yaml_qubits_cholesky_params, "qubits_L11");
-  cholesky_params[GATES_L21_INDEX] =
+  cholesky_params[to_index(CholeskyParamIndex::GatesL21)] =
       get_double(yaml_qubits_cholesky_params, "gates_L21");
-  cholesky_params[GATES_L22_INDEX] =
+  cholesky_params[to_index(CholeskyParamIndex::GatesL22)] =
       get_double(yaml_qubits_cholesky_params, "gates_L22");
-  cholesky_params[OPERATIONS_L21_INDEX] =
+  cholesky_params[to_index(CholeskyParamIndex::OperationsL21)] =
       get_double(yaml_qubits_cholesky_params, "operations_L21");
-  cholesky_params[OPERATIONS_L22_INDEX] =
+  cholesky_params[to_index(CholeskyParamIndex::OperationsL22)] =
       get_double(yaml_qubits_cholesky_params, "operations_L22");
-  cholesky_params[MEASUREMENTS_L21_INDEX] =
+  cholesky_params[to_index(CholeskyParamIndex::MeasurementsL21)] =
       get_double(yaml_qubits_cholesky_params, "measurements_L21");
-  cholesky_params[MEASUREMENTS_L22_INDEX] =
+  cholesky_params[to_index(CholeskyParamIndex::MeasurementsL22)] =
       get_double(yaml_qubits_cholesky_params, "measurements_L22");
 
   std::array<unsigned int, GATES_WEIGHTS_SIZE> gates_weights{};
 
-  gates_weights[X_INDEX] = get_unsigned(yaml_gates_weights, "X");
-  gates_weights[CX_INDEX] = get_unsigned(yaml_gates_weights, "CX");
-  gates_weights[CCX_INDEX] = get_unsigned(yaml_gates_weights, "CCX");
-  gates_weights[C3plus_X_INDEX] = get_unsigned(yaml_gates_weights, "C3plus_X");
-  gates_weights[Y_INDEX] = get_unsigned(yaml_gates_weights, "Y");
-  gates_weights[controlled_Y_INDEX] =
+  gates_weights[to_index(GateWeightIndex::X)] =
+      get_unsigned(yaml_gates_weights, "X");
+  gates_weights[to_index(GateWeightIndex::CX)] =
+      get_unsigned(yaml_gates_weights, "CX");
+  gates_weights[to_index(GateWeightIndex::CCX)] =
+      get_unsigned(yaml_gates_weights, "CCX");
+  gates_weights[to_index(GateWeightIndex::C3PlusX)] =
+      get_unsigned(yaml_gates_weights, "C3plus_X");
+  gates_weights[to_index(GateWeightIndex::Y)] =
+      get_unsigned(yaml_gates_weights, "Y");
+  gates_weights[to_index(GateWeightIndex::ControlledY)] =
       get_unsigned(yaml_gates_weights, "controlled_Y");
-  gates_weights[Z_INDEX] = get_unsigned(yaml_gates_weights, "Z");
-  gates_weights[controlled_Z_INDEX] =
+  gates_weights[to_index(GateWeightIndex::Z)] =
+      get_unsigned(yaml_gates_weights, "Z");
+  gates_weights[to_index(GateWeightIndex::ControlledZ)] =
       get_unsigned(yaml_gates_weights, "controlled_Z");
-  gates_weights[H_INDEX] = get_unsigned(yaml_gates_weights, "H");
-  gates_weights[controlled_H_INDEX] =
+  gates_weights[to_index(GateWeightIndex::H)] =
+      get_unsigned(yaml_gates_weights, "H");
+  gates_weights[to_index(GateWeightIndex::ControlledH)] =
       get_unsigned(yaml_gates_weights, "controlled_H");
-  gates_weights[S_INDEX] = get_unsigned(yaml_gates_weights, "S");
-  gates_weights[controlled_S_INDEX] =
+  gates_weights[to_index(GateWeightIndex::S)] =
+      get_unsigned(yaml_gates_weights, "S");
+  gates_weights[to_index(GateWeightIndex::ControlledS)] =
       get_unsigned(yaml_gates_weights, "controlled_S");
-  gates_weights[SDG_INDEX] = get_unsigned(yaml_gates_weights, "SDG");
-  gates_weights[controlled_SDG_INDEX] =
+  gates_weights[to_index(GateWeightIndex::SDG)] =
+      get_unsigned(yaml_gates_weights, "SDG");
+  gates_weights[to_index(GateWeightIndex::ControlledSDG)] =
       get_unsigned(yaml_gates_weights, "controlled_SDG");
-  gates_weights[T_INDEX] = get_unsigned(yaml_gates_weights, "T");
-  gates_weights[controlled_T_INDEX] =
+  gates_weights[to_index(GateWeightIndex::T)] =
+      get_unsigned(yaml_gates_weights, "T");
+  gates_weights[to_index(GateWeightIndex::ControlledT)] =
       get_unsigned(yaml_gates_weights, "controlled_T");
-  gates_weights[TDG_INDEX] = get_unsigned(yaml_gates_weights, "TDG");
-  gates_weights[controlled_TDG_INDEX] =
+  gates_weights[to_index(GateWeightIndex::TDG)] =
+      get_unsigned(yaml_gates_weights, "TDG");
+  gates_weights[to_index(GateWeightIndex::ControlledTDG)] =
       get_unsigned(yaml_gates_weights, "controlled_TDG");
-  gates_weights[RX_INDEX] = get_unsigned(yaml_gates_weights, "RX");
-  gates_weights[controlled_RX_INDEX] =
+  gates_weights[to_index(GateWeightIndex::RX)] =
+      get_unsigned(yaml_gates_weights, "RX");
+  gates_weights[to_index(GateWeightIndex::ControlledRX)] =
       get_unsigned(yaml_gates_weights, "controlled_RX");
-  gates_weights[RY_INDEX] = get_unsigned(yaml_gates_weights, "RY");
-  gates_weights[controlled_RY_INDEX] =
+  gates_weights[to_index(GateWeightIndex::RY)] =
+      get_unsigned(yaml_gates_weights, "RY");
+  gates_weights[to_index(GateWeightIndex::ControlledRY)] =
       get_unsigned(yaml_gates_weights, "controlled_RY");
-  gates_weights[RZ_INDEX] = get_unsigned(yaml_gates_weights, "RZ");
-  gates_weights[controlled_RZ_INDEX] =
+  gates_weights[to_index(GateWeightIndex::RZ)] =
+      get_unsigned(yaml_gates_weights, "RZ");
+  gates_weights[to_index(GateWeightIndex::ControlledRZ)] =
       get_unsigned(yaml_gates_weights, "controlled_RZ");
-  gates_weights[SWAP_INDEX] = get_unsigned(yaml_gates_weights, "SWAP");
-  gates_weights[controlled_SWAP_INDEX] =
+  gates_weights[to_index(GateWeightIndex::SWAP)] =
+      get_unsigned(yaml_gates_weights, "SWAP");
+  gates_weights[to_index(GateWeightIndex::ControlledSWAP)] =
       get_unsigned(yaml_gates_weights, "controlled_SWAP");
-  gates_weights[R1_INDEX] = get_unsigned(yaml_gates_weights, "R1");
-  gates_weights[controlled_R1_INDEX] =
+  gates_weights[to_index(GateWeightIndex::R1)] =
+      get_unsigned(yaml_gates_weights, "R1");
+  gates_weights[to_index(GateWeightIndex::ControlledR1)] =
       get_unsigned(yaml_gates_weights, "controlled_R1");
-  gates_weights[U2_INDEX] = get_unsigned(yaml_gates_weights, "U2");
-  gates_weights[controlled_U2_INDEX] =
+  gates_weights[to_index(GateWeightIndex::U2)] =
+      get_unsigned(yaml_gates_weights, "U2");
+  gates_weights[to_index(GateWeightIndex::ControlledU2)] =
       get_unsigned(yaml_gates_weights, "controlled_U2");
-  gates_weights[U3_INDEX] = get_unsigned(yaml_gates_weights, "U3");
-  gates_weights[controlled_U3_INDEX] =
+  gates_weights[to_index(GateWeightIndex::U3)] =
+      get_unsigned(yaml_gates_weights, "U3");
+  gates_weights[to_index(GateWeightIndex::ControlledU3)] =
       get_unsigned(yaml_gates_weights, "controlled_U3");
-  gates_weights[PHASED_RX_INDEX] =
+  gates_weights[to_index(GateWeightIndex::PhasedRX)] =
       get_unsigned(yaml_gates_weights, "PHASED_RX");
-  gates_weights[controlled_PHASED_RX_INDEX] =
+  gates_weights[to_index(GateWeightIndex::ControlledPhasedRX)] =
       get_unsigned(yaml_gates_weights, "controlled_PHASED_RX");
-  gates_weights[MX_INDEX] = get_unsigned(yaml_gates_weights, "MX");
-  gates_weights[MY_INDEX] = get_unsigned(yaml_gates_weights, "MY");
-  gates_weights[MZ_INDEX] = get_unsigned(yaml_gates_weights, "MZ");
+  gates_weights[to_index(GateWeightIndex::MX)] =
+      get_unsigned(yaml_gates_weights, "MX");
+  gates_weights[to_index(GateWeightIndex::MY)] =
+      get_unsigned(yaml_gates_weights, "MY");
+  gates_weights[to_index(GateWeightIndex::MZ)] =
+      get_unsigned(yaml_gates_weights, "MZ");
 
   return random_quantum_circuit_from_embedded_statistics(
       cholesky_params, gates_weights, randomizer_options);

--- a/AI/src/Environment/statistics_for_rqcg.cpp
+++ b/AI/src/Environment/statistics_for_rqcg.cpp
@@ -69,11 +69,11 @@ extract_dataset_statistics(const std::string &dataset_name) {
       }
       if (isMeasurement(op)) {
         if (isa<quake::MxOp>(op)) {
-          gates_weights[MX_INDEX]++;
+          gates_weights[to_index(GateWeightIndex::MX)]++;
         } else if (isa<quake::MyOp>(op)) {
-          gates_weights[MY_INDEX]++;
+          gates_weights[to_index(GateWeightIndex::MY)]++;
         } else if (isa<quake::MzOp>(op)) {
-          gates_weights[MZ_INDEX]++;
+          gates_weights[to_index(GateWeightIndex::MZ)]++;
         } else {
           throw std::runtime_error("Measurement gate op not Mx|My|Mz.");
         }
@@ -114,120 +114,120 @@ extract_dataset_statistics(const std::string &dataset_name) {
       switch (GATE_INDEX(getOnlyGateName(op))) {
       case X:
         if (nr_controls <= 0) {
-          gates_weights[X_INDEX]++;
+          gates_weights[to_index(GateWeightIndex::X)]++;
         } else if (nr_controls == 1) {
-          gates_weights[CX_INDEX]++;
+          gates_weights[to_index(GateWeightIndex::CX)]++;
         } else if (nr_controls == 2) {
-          gates_weights[CCX_INDEX]++;
+          gates_weights[to_index(GateWeightIndex::CCX)]++;
         } else {
-          gates_weights[C3plus_X_INDEX]++;
+          gates_weights[to_index(GateWeightIndex::C3PlusX)]++;
         }
         break;
       case Y:
         if (nr_controls <= 0) {
-          gates_weights[Y_INDEX]++;
+          gates_weights[to_index(GateWeightIndex::Y)]++;
         } else {
-          gates_weights[controlled_Y_INDEX]++;
+          gates_weights[to_index(GateWeightIndex::ControlledY)]++;
         }
         break;
       case Z:
         if (nr_controls <= 0) {
-          gates_weights[Z_INDEX]++;
+          gates_weights[to_index(GateWeightIndex::Z)]++;
         } else {
-          gates_weights[controlled_Z_INDEX]++;
+          gates_weights[to_index(GateWeightIndex::ControlledZ)]++;
         }
         break;
       case H:
         if (nr_controls <= 0) {
-          gates_weights[H_INDEX]++;
+          gates_weights[to_index(GateWeightIndex::H)]++;
         } else {
-          gates_weights[controlled_H_INDEX]++;
+          gates_weights[to_index(GateWeightIndex::ControlledH)]++;
         }
         break;
       case S:
         if (nr_controls <= 0) {
           if (isAdj) {
-            gates_weights[SDG_INDEX]++;
+            gates_weights[to_index(GateWeightIndex::SDG)]++;
           } else {
-            gates_weights[S_INDEX]++;
+            gates_weights[to_index(GateWeightIndex::S)]++;
           }
         } else {
           if (isAdj) {
-            gates_weights[controlled_SDG_INDEX]++;
+            gates_weights[to_index(GateWeightIndex::ControlledSDG)]++;
           } else {
-            gates_weights[controlled_S_INDEX]++;
+            gates_weights[to_index(GateWeightIndex::ControlledS)]++;
           }
         }
         break;
       case T:
         if (nr_controls <= 0) {
           if (isAdj) {
-            gates_weights[TDG_INDEX]++;
+            gates_weights[to_index(GateWeightIndex::TDG)]++;
           } else {
-            gates_weights[T_INDEX]++;
+            gates_weights[to_index(GateWeightIndex::T)]++;
           }
         } else {
           if (isAdj) {
-            gates_weights[controlled_TDG_INDEX]++;
+            gates_weights[to_index(GateWeightIndex::ControlledTDG)]++;
           } else {
-            gates_weights[controlled_T_INDEX]++;
+            gates_weights[to_index(GateWeightIndex::ControlledT)]++;
           }
         }
         break;
       case RX:
         if (nr_controls <= 0) {
-          gates_weights[RX_INDEX]++;
+          gates_weights[to_index(GateWeightIndex::RX)]++;
         } else {
-          gates_weights[controlled_RX_INDEX]++;
+          gates_weights[to_index(GateWeightIndex::ControlledRX)]++;
         }
         break;
       case RY:
         if (nr_controls <= 0) {
-          gates_weights[RY_INDEX]++;
+          gates_weights[to_index(GateWeightIndex::RY)]++;
         } else {
-          gates_weights[controlled_RY_INDEX]++;
+          gates_weights[to_index(GateWeightIndex::ControlledRY)]++;
         }
         break;
       case RZ:
         if (nr_controls <= 0) {
-          gates_weights[RZ_INDEX]++;
+          gates_weights[to_index(GateWeightIndex::RZ)]++;
         } else {
-          gates_weights[controlled_RZ_INDEX]++;
+          gates_weights[to_index(GateWeightIndex::ControlledRZ)]++;
         }
         break;
       case SWAP:
         if (nr_controls <= 0) {
-          gates_weights[SWAP_INDEX]++;
+          gates_weights[to_index(GateWeightIndex::SWAP)]++;
         } else {
-          gates_weights[controlled_SWAP_INDEX]++;
+          gates_weights[to_index(GateWeightIndex::ControlledSWAP)]++;
         }
         break;
       case R1:
         if (nr_controls <= 0) {
-          gates_weights[R1_INDEX]++;
+          gates_weights[to_index(GateWeightIndex::R1)]++;
         } else {
-          gates_weights[controlled_R1_INDEX]++;
+          gates_weights[to_index(GateWeightIndex::ControlledR1)]++;
         }
         break;
       case U2:
         if (nr_controls <= 0) {
-          gates_weights[U2_INDEX]++;
+          gates_weights[to_index(GateWeightIndex::U2)]++;
         } else {
-          gates_weights[controlled_U2_INDEX]++;
+          gates_weights[to_index(GateWeightIndex::ControlledU2)]++;
         }
         break;
       case U3:
         if (nr_controls <= 0) {
-          gates_weights[U3_INDEX]++;
+          gates_weights[to_index(GateWeightIndex::U3)]++;
         } else {
-          gates_weights[controlled_U3_INDEX]++;
+          gates_weights[to_index(GateWeightIndex::ControlledU3)]++;
         }
         break;
       case PHASED_RX:
         if (nr_controls <= 0) {
-          gates_weights[PHASED_RX_INDEX]++;
+          gates_weights[to_index(GateWeightIndex::PhasedRX)]++;
         } else {
-          gates_weights[controlled_PHASED_RX_INDEX]++;
+          gates_weights[to_index(GateWeightIndex::ControlledPhasedRX)]++;
         }
         break;
       default:
@@ -298,63 +298,63 @@ extract_dataset_statistics(const std::string &dataset_name) {
   variance_measurements /= N - 1;
   covariance_measurements /= N - 1;
   std::array<double, CHOLESKY_PARAMS_SIZE> cholesky_params{};
-  cholesky_params[MEAN_QUBITS_INDEX] = mean_qubits;
-  cholesky_params[MEAN_GATES_INDEX] = mean_gates;
-  cholesky_params[MEAN_OPERATIONS_INDEX] = mean_operations;
-  cholesky_params[MEAN_MEASUREMENTS_INDEX] = mean_measurements;
-  cholesky_params[QUBITS_L11_INDEX] = std::sqrt(variance_qubits);
+  cholesky_params[to_index(CholeskyParamIndex::MeanQubits)] = mean_qubits;
+  cholesky_params[to_index(CholeskyParamIndex::MeanGates)] = mean_gates;
+  cholesky_params[to_index(CholeskyParamIndex::MeanOperations)] = mean_operations;
+  cholesky_params[to_index(CholeskyParamIndex::MeanMeasurements)] = mean_measurements;
+  cholesky_params[to_index(CholeskyParamIndex::QubitsL11)] = std::sqrt(variance_qubits);
 
   if (variance_qubits <= 0.0) {
-    cholesky_params[GATES_L21_INDEX] = 0.0;
-    cholesky_params[GATES_L22_INDEX] = std::sqrt(variance_gates);
-    cholesky_params[OPERATIONS_L21_INDEX] = 0.0;
-    cholesky_params[OPERATIONS_L22_INDEX] = std::sqrt(covariance_operations);
-    cholesky_params[MEASUREMENTS_L21_INDEX] = 0.0;
-    cholesky_params[MEASUREMENTS_L22_INDEX] = std::sqrt(variance_measurements);
+    cholesky_params[to_index(CholeskyParamIndex::GatesL21)] = 0.0;
+    cholesky_params[to_index(CholeskyParamIndex::GatesL22)] = std::sqrt(variance_gates);
+    cholesky_params[to_index(CholeskyParamIndex::OperationsL21)] = 0.0;
+    cholesky_params[to_index(CholeskyParamIndex::OperationsL22)] = std::sqrt(covariance_operations);
+    cholesky_params[to_index(CholeskyParamIndex::MeasurementsL21)] = 0.0;
+    cholesky_params[to_index(CholeskyParamIndex::MeasurementsL22)] = std::sqrt(variance_measurements);
     return std::make_pair(cholesky_params, gates_weights);
   }
   if (variance_gates <= 0.0) {
-    cholesky_params[GATES_L21_INDEX] = 0.0;
-    cholesky_params[GATES_L22_INDEX] = 0.0;
+    cholesky_params[to_index(CholeskyParamIndex::GatesL21)] = 0.0;
+    cholesky_params[to_index(CholeskyParamIndex::GatesL22)] = 0.0;
   } else if (double determinant = variance_qubits * variance_gates -
                                   covariance_gates * covariance_gates;
              determinant <= 0.0) {
     return std::nullopt;
   } else {
-    cholesky_params[GATES_L21_INDEX] =
-        covariance_gates / cholesky_params[QUBITS_L11_INDEX];
-    cholesky_params[GATES_L22_INDEX] =
-        std::sqrt(variance_gates - cholesky_params[GATES_L21_INDEX] *
-                                       cholesky_params[GATES_L21_INDEX]);
+    cholesky_params[to_index(CholeskyParamIndex::GatesL21)] =
+        covariance_gates / cholesky_params[to_index(CholeskyParamIndex::QubitsL11)];
+    cholesky_params[to_index(CholeskyParamIndex::GatesL22)] =
+        std::sqrt(variance_gates - cholesky_params[to_index(CholeskyParamIndex::GatesL21)] *
+                                       cholesky_params[to_index(CholeskyParamIndex::GatesL21)]);
   }
   if (variance_operations <= 0.0) {
-    cholesky_params[OPERATIONS_L21_INDEX] = 0.0;
-    cholesky_params[OPERATIONS_L22_INDEX] = 0.0;
+    cholesky_params[to_index(CholeskyParamIndex::OperationsL21)] = 0.0;
+    cholesky_params[to_index(CholeskyParamIndex::OperationsL22)] = 0.0;
   } else if (double determinant = variance_qubits * variance_operations -
                                   covariance_operations * covariance_operations;
              determinant <= 0.0) {
     return std::nullopt;
   } else {
-    cholesky_params[OPERATIONS_L21_INDEX] =
-        covariance_operations / cholesky_params[QUBITS_L11_INDEX];
-    cholesky_params[OPERATIONS_L22_INDEX] = std::sqrt(
-        variance_operations - cholesky_params[OPERATIONS_L21_INDEX] *
-                                  cholesky_params[OPERATIONS_L21_INDEX]);
+    cholesky_params[to_index(CholeskyParamIndex::OperationsL21)] =
+        covariance_operations / cholesky_params[to_index(CholeskyParamIndex::QubitsL11)];
+    cholesky_params[to_index(CholeskyParamIndex::OperationsL22)] = std::sqrt(
+        variance_operations - cholesky_params[to_index(CholeskyParamIndex::OperationsL21)] *
+                                  cholesky_params[to_index(CholeskyParamIndex::OperationsL21)]);
   }
   if (variance_measurements <= 0.0) {
-    cholesky_params[MEASUREMENTS_L21_INDEX] = 0.0;
-    cholesky_params[MEASUREMENTS_L22_INDEX] = 0.0;
+    cholesky_params[to_index(CholeskyParamIndex::MeasurementsL21)] = 0.0;
+    cholesky_params[to_index(CholeskyParamIndex::MeasurementsL22)] = 0.0;
   } else if (double determinant =
                  variance_qubits * variance_measurements -
                  covariance_measurements * covariance_measurements;
              determinant <= 0.0) {
     return std::nullopt;
   } else {
-    cholesky_params[MEASUREMENTS_L21_INDEX] =
-        covariance_measurements / cholesky_params[QUBITS_L11_INDEX];
-    cholesky_params[MEASUREMENTS_L22_INDEX] = std::sqrt(
-        variance_measurements - cholesky_params[MEASUREMENTS_L21_INDEX] *
-                                    cholesky_params[MEASUREMENTS_L21_INDEX]);
+    cholesky_params[to_index(CholeskyParamIndex::MeasurementsL21)] =
+        covariance_measurements / cholesky_params[to_index(CholeskyParamIndex::QubitsL11)];
+    cholesky_params[to_index(CholeskyParamIndex::MeasurementsL22)] = std::sqrt(
+        variance_measurements - cholesky_params[to_index(CholeskyParamIndex::MeasurementsL21)] *
+                                    cholesky_params[to_index(CholeskyParamIndex::MeasurementsL21)]);
   }
   return std::make_pair(cholesky_params, gates_weights);
 }
@@ -369,79 +369,79 @@ void print_dataset_statistics(const std::string &dataset_name) {
   auto [cholesky_params, gates_weights] = dataset_statistics.value();
   std::cout << "dataset_name: \"" << dataset_name << "\"" << std::endl;
   std::cout << "cholesky_params: " << std::endl;
-  std::cout << "  mean_qubits: " << cholesky_params[MEAN_QUBITS_INDEX]
+  std::cout << "  mean_qubits: " << cholesky_params[to_index(CholeskyParamIndex::MeanQubits)]
             << std::endl;
-  std::cout << "  mean_gates: " << cholesky_params[MEAN_GATES_INDEX]
+  std::cout << "  mean_gates: " << cholesky_params[to_index(CholeskyParamIndex::MeanGates)]
             << std::endl;
-  std::cout << "  mean_operations: " << cholesky_params[MEAN_OPERATIONS_INDEX]
+  std::cout << "  mean_operations: " << cholesky_params[to_index(CholeskyParamIndex::MeanOperations)]
             << std::endl;
   std::cout << "  mean_measurements: "
-            << cholesky_params[MEAN_MEASUREMENTS_INDEX] << std::endl;
-  std::cout << "  qubits_L11: " << cholesky_params[QUBITS_L11_INDEX]
+            << cholesky_params[to_index(CholeskyParamIndex::MeanMeasurements)] << std::endl;
+  std::cout << "  qubits_L11: " << cholesky_params[to_index(CholeskyParamIndex::QubitsL11)]
             << std::endl;
-  std::cout << "  gates_L21: " << cholesky_params[GATES_L21_INDEX] << std::endl;
-  std::cout << "  gates_L22: " << cholesky_params[GATES_L22_INDEX] << std::endl;
-  std::cout << "  operations_L21: " << cholesky_params[OPERATIONS_L21_INDEX]
+  std::cout << "  gates_L21: " << cholesky_params[to_index(CholeskyParamIndex::GatesL21)] << std::endl;
+  std::cout << "  gates_L22: " << cholesky_params[to_index(CholeskyParamIndex::GatesL22)] << std::endl;
+  std::cout << "  operations_L21: " << cholesky_params[to_index(CholeskyParamIndex::OperationsL21)]
             << std::endl;
-  std::cout << "  operations_L22: " << cholesky_params[OPERATIONS_L22_INDEX]
+  std::cout << "  operations_L22: " << cholesky_params[to_index(CholeskyParamIndex::OperationsL22)]
             << std::endl;
-  std::cout << "  measurements_L21: " << cholesky_params[MEASUREMENTS_L21_INDEX]
+  std::cout << "  measurements_L21: " << cholesky_params[to_index(CholeskyParamIndex::MeasurementsL21)]
             << std::endl;
-  std::cout << "  measurements_L22: " << cholesky_params[MEASUREMENTS_L22_INDEX]
+  std::cout << "  measurements_L22: " << cholesky_params[to_index(CholeskyParamIndex::MeasurementsL22)]
             << std::endl;
   std::cout << "gates_weights:" << std::endl;
-  std::cout << "  X: " << gates_weights[X_INDEX] << std::endl;
-  std::cout << "  CX: " << gates_weights[CX_INDEX] << std::endl;
-  std::cout << "  CCX: " << gates_weights[CCX_INDEX] << std::endl;
-  std::cout << "  C3plus_X: " << gates_weights[C3plus_X_INDEX] << std::endl;
-  std::cout << "  Y: " << gates_weights[Y_INDEX] << std::endl;
-  std::cout << "  controlled_Y: " << gates_weights[controlled_Y_INDEX]
+  std::cout << "  X: " << gates_weights[to_index(GateWeightIndex::X)] << std::endl;
+  std::cout << "  CX: " << gates_weights[to_index(GateWeightIndex::CX)] << std::endl;
+  std::cout << "  CCX: " << gates_weights[to_index(GateWeightIndex::CCX)] << std::endl;
+  std::cout << "  C3plus_X: " << gates_weights[to_index(GateWeightIndex::C3PlusX)] << std::endl;
+  std::cout << "  Y: " << gates_weights[to_index(GateWeightIndex::Y)] << std::endl;
+  std::cout << "  controlled_Y: " << gates_weights[to_index(GateWeightIndex::ControlledY)]
             << std::endl;
-  std::cout << "  Z: " << gates_weights[Z_INDEX] << std::endl;
-  std::cout << "  controlled_Z: " << gates_weights[controlled_Z_INDEX]
+  std::cout << "  Z: " << gates_weights[to_index(GateWeightIndex::Z)] << std::endl;
+  std::cout << "  controlled_Z: " << gates_weights[to_index(GateWeightIndex::ControlledZ)]
             << std::endl;
-  std::cout << "  H: " << gates_weights[H_INDEX] << std::endl;
-  std::cout << "  controlled_H: " << gates_weights[controlled_H_INDEX]
+  std::cout << "  H: " << gates_weights[to_index(GateWeightIndex::H)] << std::endl;
+  std::cout << "  controlled_H: " << gates_weights[to_index(GateWeightIndex::ControlledH)]
             << std::endl;
-  std::cout << "  S: " << gates_weights[S_INDEX] << std::endl;
-  std::cout << "  controlled_S: " << gates_weights[controlled_S_INDEX]
+  std::cout << "  S: " << gates_weights[to_index(GateWeightIndex::S)] << std::endl;
+  std::cout << "  controlled_S: " << gates_weights[to_index(GateWeightIndex::ControlledS)]
             << std::endl;
-  std::cout << "  SDG: " << gates_weights[SDG_INDEX] << std::endl;
-  std::cout << "  controlled_SDG: " << gates_weights[controlled_SDG_INDEX]
+  std::cout << "  SDG: " << gates_weights[to_index(GateWeightIndex::SDG)] << std::endl;
+  std::cout << "  controlled_SDG: " << gates_weights[to_index(GateWeightIndex::ControlledSDG)]
             << std::endl;
-  std::cout << "  T: " << gates_weights[T_INDEX] << std::endl;
-  std::cout << "  controlled_T: " << gates_weights[controlled_T_INDEX]
+  std::cout << "  T: " << gates_weights[to_index(GateWeightIndex::T)] << std::endl;
+  std::cout << "  controlled_T: " << gates_weights[to_index(GateWeightIndex::ControlledT)]
             << std::endl;
-  std::cout << "  TDG: " << gates_weights[TDG_INDEX] << std::endl;
-  std::cout << "  controlled_TDG: " << gates_weights[controlled_TDG_INDEX]
+  std::cout << "  TDG: " << gates_weights[to_index(GateWeightIndex::TDG)] << std::endl;
+  std::cout << "  controlled_TDG: " << gates_weights[to_index(GateWeightIndex::ControlledTDG)]
             << std::endl;
-  std::cout << "  RX: " << gates_weights[RX_INDEX] << std::endl;
-  std::cout << "  controlled_RX: " << gates_weights[controlled_RX_INDEX]
+  std::cout << "  RX: " << gates_weights[to_index(GateWeightIndex::RX)] << std::endl;
+  std::cout << "  controlled_RX: " << gates_weights[to_index(GateWeightIndex::ControlledRX)]
             << std::endl;
-  std::cout << "  RY: " << gates_weights[RY_INDEX] << std::endl;
-  std::cout << "  controlled_RY: " << gates_weights[controlled_RY_INDEX]
+  std::cout << "  RY: " << gates_weights[to_index(GateWeightIndex::RY)] << std::endl;
+  std::cout << "  controlled_RY: " << gates_weights[to_index(GateWeightIndex::ControlledRY)]
             << std::endl;
-  std::cout << "  RZ: " << gates_weights[RZ_INDEX] << std::endl;
-  std::cout << "  controlled_RZ: " << gates_weights[controlled_RZ_INDEX]
+  std::cout << "  RZ: " << gates_weights[to_index(GateWeightIndex::RZ)] << std::endl;
+  std::cout << "  controlled_RZ: " << gates_weights[to_index(GateWeightIndex::ControlledRZ)]
             << std::endl;
-  std::cout << "  SWAP: " << gates_weights[SWAP_INDEX] << std::endl;
-  std::cout << "  controlled_SWAP: " << gates_weights[controlled_SWAP_INDEX]
+  std::cout << "  SWAP: " << gates_weights[to_index(GateWeightIndex::SWAP)] << std::endl;
+  std::cout << "  controlled_SWAP: " << gates_weights[to_index(GateWeightIndex::ControlledSWAP)]
             << std::endl;
-  std::cout << "  R1: " << gates_weights[R1_INDEX] << std::endl;
-  std::cout << "  controlled_R1: " << gates_weights[controlled_R1_INDEX]
+  std::cout << "  R1: " << gates_weights[to_index(GateWeightIndex::R1)] << std::endl;
+  std::cout << "  controlled_R1: " << gates_weights[to_index(GateWeightIndex::ControlledR1)]
             << std::endl;
-  std::cout << "  U2: " << gates_weights[U2_INDEX] << std::endl;
-  std::cout << "  controlled_U2: " << gates_weights[controlled_U2_INDEX]
+  std::cout << "  U2: " << gates_weights[to_index(GateWeightIndex::U2)] << std::endl;
+  std::cout << "  controlled_U2: " << gates_weights[to_index(GateWeightIndex::ControlledU2)]
             << std::endl;
-  std::cout << "  U3: " << gates_weights[U3_INDEX] << std::endl;
-  std::cout << "  controlled_U3: " << gates_weights[controlled_U3_INDEX]
+  std::cout << "  U3: " << gates_weights[to_index(GateWeightIndex::U3)] << std::endl;
+  std::cout << "  controlled_U3: " << gates_weights[to_index(GateWeightIndex::ControlledU3)]
             << std::endl;
-  std::cout << "  PHASED_RX: " << gates_weights[PHASED_RX_INDEX] << std::endl;
+  std::cout << "  PHASED_RX: " << gates_weights[to_index(GateWeightIndex::PhasedRX)] << std::endl;
   std::cout << "  controlled_PHASED_RX: "
-            << gates_weights[controlled_PHASED_RX_INDEX] << std::endl;
-  std::cout << "  MX: " << gates_weights[MX_INDEX] << std::endl;
-  std::cout << "  MY: " << gates_weights[MY_INDEX] << std::endl;
-  std::cout << "  MZ: " << gates_weights[MZ_INDEX] << std::endl;
+            << gates_weights[to_index(GateWeightIndex::ControlledPhasedRX)] << std::endl;
+  std::cout << "  MX: " << gates_weights[to_index(GateWeightIndex::MX)] << std::endl;
+  std::cout << "  MY: " << gates_weights[to_index(GateWeightIndex::MY)] << std::endl;
+  std::cout << "  MZ: " << gates_weights[to_index(GateWeightIndex::MZ)] << std::endl;
 }
 
 std::optional<std::pair<std::array<double, CHOLESKY_PARAMS_SIZE>,

--- a/AI/src/NeuralNetworks/Agents/agent_utils.cpp
+++ b/AI/src/NeuralNetworks/Agents/agent_utils.cpp
@@ -29,7 +29,7 @@ AgentAttributes parseAgentName(const std::string &agent_name) {
       AGENT_NAME_TO_CLASS.end()) {
     throw std::runtime_error("Unsupported agent: " + agent_attributes[0]);
   }
-  int agent_class = AGENT_NAME_TO_CLASS.at(agent_attributes[0]);
+  AgentClass agent_class = AGENT_NAME_TO_CLASS.at(agent_attributes[0]);
   if (agent_attributes[1].rfind("mq", 0) != 0) {
     throw std::invalid_argument("Missing <mq> prefix");
   }
@@ -39,30 +39,31 @@ AgentAttributes parseAgentName(const std::string &agent_name) {
 }
 
 std::unique_ptr<torch::optim::Optimizer>
-makeOptimizer(int optimizerType, const torch::nn::Sequential &agentModel,
+makeOptimizer(OptimizerType optimizerType,
+              const torch::nn::Sequential &agentModel,
               double learningRate) {
   switch (optimizerType) {
-  case OPTIMIZER_ADAGRAD:
+  case OptimizerType::Adagrad:
     return std::make_unique<torch::optim::Adagrad>(
         agentModel->parameters(), torch::optim::AdagradOptions(learningRate));
-  case OPTIMIZER_ADAM:
+  case OptimizerType::Adam:
     return std::make_unique<torch::optim::Adam>(
         agentModel->parameters(), torch::optim::AdamOptions(learningRate));
-  case OPTIMIZER_ADAMW:
+  case OptimizerType::AdamW:
     return std::make_unique<torch::optim::AdamW>(
         agentModel->parameters(), torch::optim::AdamWOptions(learningRate));
-  case OPTIMIZER_LBFGS:
+  case OptimizerType::LBFGS:
     return std::make_unique<torch::optim::LBFGS>(
         agentModel->parameters(), torch::optim::LBFGSOptions(learningRate));
-  case OPTIMIZER_RMSPROP:
+  case OptimizerType::RMSProp:
     return std::make_unique<torch::optim::RMSprop>(
         agentModel->parameters(), torch::optim::RMSpropOptions(learningRate));
-  case OPTIMIZER_SGD:
+  case OptimizerType::SGD:
     return std::make_unique<torch::optim::SGD>(
         agentModel->parameters(), torch::optim::SGDOptions(learningRate));
   default:
     throw std::runtime_error("Unsupported optimizer type: " +
-                             std::to_string(optimizerType));
+                             std::to_string(static_cast<int>(optimizerType)));
   }
 }
 
@@ -113,7 +114,7 @@ getRecommendedPasses(const std::string &agent_name, const std::string &circuit,
     std::cerr << "Unsupported agent: " << agent_attributes[0] << std::endl;
     return {};
   }
-  int agent_class = AGENT_NAME_TO_CLASS.at(agent_attributes[0]);
+  AgentClass agent_class = AGENT_NAME_TO_CLASS.at(agent_attributes[0]);
   if (agent_attributes[1].rfind("mq", 0) != 0) {
     throw std::invalid_argument("Missing 'mq' prefix");
   }

--- a/AI/src/NeuralNetworks/Agents/base_actor_critic.cpp
+++ b/AI/src/NeuralNetworks/Agents/base_actor_critic.cpp
@@ -21,8 +21,10 @@ BaseActorCritic::BaseActorCritic(unsigned int max_qubits)
   this->actor_learning_rate = GLOBAL_PARAMS["actor_learning_rate"].to_double();
   this->critic_learning_rate =
       GLOBAL_PARAMS["critic_learning_rate"].to_double();
-  this->actor_optimizer_type = GLOBAL_PARAMS["actor_optimizer_type"].to_int();
-  this->critic_optimizer_type = GLOBAL_PARAMS["critic_optimizer_type"].to_int();
+  this->actor_optimizer_type = static_cast<OptimizerType>(
+      GLOBAL_PARAMS["actor_optimizer_type"].to_int());
+  this->critic_optimizer_type = static_cast<OptimizerType>(
+      GLOBAL_PARAMS["critic_optimizer_type"].to_int());
 }
 
 bool BaseActorCritic::initialize(const torch::nn::Sequential &actor,

--- a/AI/src/NeuralNetworks/Agents/training_and_run_manager.cpp
+++ b/AI/src/NeuralNetworks/Agents/training_and_run_manager.cpp
@@ -27,7 +27,7 @@ train(const std::string &agent_name, const std::string &dataset) {
   try {
     switch (AgentAttributes attributes = parseAgentName(agent_name);
             attributes.agent_class) {
-    case A3C: {
+    case AgentClass::A3C: {
       std::unique_ptr<BaseA3CAgent> agent;
       if (attributes.extras == "tcnrelu") {
         agent = std::make_unique<A3C_TCN_RELU>(attributes.max_qubits);

--- a/AI/src/Utils/info_utils.cpp
+++ b/AI/src/Utils/info_utils.cpp
@@ -226,7 +226,7 @@ void print_agent_info(const std::string &agent_name) {
   try {
     switch (AgentAttributes attributes = parseAgentName(agent_name);
             attributes.agent_class) {
-    case A3C: {
+    case AgentClass::A3C: {
       std::unique_ptr<BaseA3CAgent> agent;
       if (attributes.extras == "tcnrelu") {
         agent = std::make_unique<A3C_TCN_RELU>(attributes.max_qubits);

--- a/AI/src/Utils/tensor_utils.cpp
+++ b/AI/src/Utils/tensor_utils.cpp
@@ -121,7 +121,7 @@ std::vector<Value> RebuildSetup::getRefs(const std::vector<int> &indexes) {
   return refsVector;
 }
 
-void insertMeasurements(RebuildSetup &rebuildSetup, int gateIndex,
+void insertMeasurements(RebuildSetup &rebuildSetup, GateSymbol gate,
                         ValueRange targets) {
   if (targets.empty()) {
     throw std::runtime_error("Measurement needs at least 1 target.");
@@ -129,26 +129,26 @@ void insertMeasurements(RebuildSetup &rebuildSetup, int gateIndex,
   llvm::SmallVector<Value> targetsVec(targets.begin(), targets.end());
   mlir::Type measureType =
       quake::MeasureType::get(rebuildSetup.builder.getContext());
-  switch (gateIndex) {
-  case MX:
+  switch (gate) {
+  case GateSymbol::MX:
     rebuildSetup.builder.create<quake::MxOp>(rebuildSetup.loc, measureType,
                                              targetsVec);
     break;
-  case MY:
+  case GateSymbol::MY:
     rebuildSetup.builder.create<quake::MyOp>(rebuildSetup.loc, measureType,
                                              targetsVec);
     break;
-  case MZ:
+  case GateSymbol::MZ:
     rebuildSetup.builder.create<quake::MzOp>(rebuildSetup.loc, measureType,
                                              targetsVec);
     break;
   default:
     throw std::runtime_error("Not a measurement: " +
-                             std::string(SUPPORTED_GATES[gateIndex]));
+                             std::string(SUPPORTED_GATES[to_gate_index(gate)]));
   }
 }
 
-void insertGate(RebuildSetup &rebuildSetup, int gateIndex,
+void insertGate(RebuildSetup &rebuildSetup, GateSymbol gate,
                 const std::vector<int> &targetIndexes,
                 const std::vector<int> &controlIndexes,
                 const std::vector<float> &angles, bool isAdj) {
@@ -160,70 +160,70 @@ void insertGate(RebuildSetup &rebuildSetup, int gateIndex,
   ValueRange controls(controlVals);
   ValueRange targets(targetVals);
   std::vector<Value> paramsVector;
-  switch (gateIndex) {
-  case X:
+  switch (gate) {
+  case GateSymbol::X:
     rebuildSetup.builder.create<quake::XOp>(rebuildSetup.loc, false,
                                             ValueRange{}, controls, targets);
     break;
-  case Y:
+  case GateSymbol::Y:
     rebuildSetup.builder.create<quake::YOp>(rebuildSetup.loc, false,
                                             ValueRange{}, controls, targets);
     break;
-  case Z:
+  case GateSymbol::Z:
     rebuildSetup.builder.create<quake::ZOp>(rebuildSetup.loc, false,
                                             ValueRange{}, controls, targets);
     break;
-  case H:
+  case GateSymbol::H:
     rebuildSetup.builder.create<quake::HOp>(rebuildSetup.loc, false,
                                             ValueRange{}, controls, targets);
     break;
-  case S:
+  case GateSymbol::S:
     rebuildSetup.builder.create<quake::SOp>(rebuildSetup.loc, isAdj,
                                             ValueRange{}, controls, targets);
     break;
-  case T:
+  case GateSymbol::T:
     rebuildSetup.builder.create<quake::TOp>(rebuildSetup.loc, isAdj,
                                             ValueRange{}, controls, targets);
     break;
-  case RX:
+  case GateSymbol::RX:
     paramsVector = {
         createFloatValue(rebuildSetup.builder, rebuildSetup.loc, angles[0])};
     rebuildSetup.builder.create<quake::RxOp>(
         rebuildSetup.loc, isAdj, ValueRange(paramsVector), controls, targets);
     break;
-  case RY:
+  case GateSymbol::RY:
     paramsVector = {
         createFloatValue(rebuildSetup.builder, rebuildSetup.loc, angles[0])};
     rebuildSetup.builder.create<quake::RyOp>(
         rebuildSetup.loc, isAdj, ValueRange(paramsVector), controls, targets);
     break;
-  case RZ:
+  case GateSymbol::RZ:
     paramsVector = {
         createFloatValue(rebuildSetup.builder, rebuildSetup.loc, angles[0])};
     rebuildSetup.builder.create<quake::RzOp>(
         rebuildSetup.loc, isAdj, ValueRange(paramsVector), controls, targets);
     break;
-  case SWAP:
+  case GateSymbol::SWAP:
     if (targets.size() != 2) {
       throw std::runtime_error("Swap requires exactly 2 targets.");
     }
     rebuildSetup.builder.create<quake::SwapOp>(rebuildSetup.loc, false,
                                                ValueRange{}, controls, targets);
     break;
-  case R1:
+  case GateSymbol::R1:
     paramsVector = {
         createFloatValue(rebuildSetup.builder, rebuildSetup.loc, angles[0])};
     rebuildSetup.builder.create<quake::R1Op>(
         rebuildSetup.loc, isAdj, ValueRange(paramsVector), controls, targets);
     break;
-  case U2:
+  case GateSymbol::U2:
     paramsVector = {
         createFloatValue(rebuildSetup.builder, rebuildSetup.loc, angles[0]),
         createFloatValue(rebuildSetup.builder, rebuildSetup.loc, angles[1])};
     rebuildSetup.builder.create<quake::U2Op>(
         rebuildSetup.loc, isAdj, ValueRange(paramsVector), controls, targets);
     break;
-  case U3:
+  case GateSymbol::U3:
     paramsVector = {
         createFloatValue(rebuildSetup.builder, rebuildSetup.loc, angles[0]),
         createFloatValue(rebuildSetup.builder, rebuildSetup.loc, angles[1]),
@@ -231,34 +231,34 @@ void insertGate(RebuildSetup &rebuildSetup, int gateIndex,
     rebuildSetup.builder.create<quake::U3Op>(
         rebuildSetup.loc, isAdj, ValueRange(paramsVector), controls, targets);
     break;
-  case PHASED_RX:
+  case GateSymbol::PHASED_RX:
     paramsVector = {
         createFloatValue(rebuildSetup.builder, rebuildSetup.loc, angles[0]),
         createFloatValue(rebuildSetup.builder, rebuildSetup.loc, angles[1])};
     rebuildSetup.builder.create<quake::PhasedRxOp>(
         rebuildSetup.loc, isAdj, ValueRange(paramsVector), controls, targets);
     break;
-  case MX:
+  case GateSymbol::MX:
     if (!controls.empty()) {
       throw std::runtime_error("Mx cannot have controls.");
     }
-    insertMeasurements(rebuildSetup, MX, targets);
+    insertMeasurements(rebuildSetup, GateSymbol::MX, targets);
     break;
-  case MY:
+  case GateSymbol::MY:
     if (!controls.empty()) {
       throw std::runtime_error("My cannot have controls.");
     }
-    insertMeasurements(rebuildSetup, MY, targets);
+    insertMeasurements(rebuildSetup, GateSymbol::MY, targets);
     break;
-  case MZ:
+  case GateSymbol::MZ:
     if (!controls.empty()) {
       throw std::runtime_error("Mz cannot have controls.");
     }
-    insertMeasurements(rebuildSetup, MZ, targets);
+    insertMeasurements(rebuildSetup, GateSymbol::MZ, targets);
     break;
   default:
     throw std::runtime_error("Unsupported gate index: " +
-                             std::to_string(gateIndex));
+                             std::to_string(to_gate_index(gate)));
   }
 }
 
@@ -357,7 +357,7 @@ recreateQuantumCircuitFromTensor(const InstructionsTensor<float> &tensor) {
       throw std::runtime_error("Nr gate angles: " +
                                std::to_string(angles.size()));
     }
-    insertGate(rebuildSetup, gateIndex, targetIndexes, controlIndexes, angles,
+    insertGate(rebuildSetup, static_cast<GateSymbol>(gateIndex), targetIndexes, controlIndexes, angles,
                isAdj);
 
     // Adjust the depths only if everything ran smoothly.


### PR DESCRIPTION
## Summary
- replace agent and optimizer constants with scoped enum classes and update all neural network agent utilities
- introduce circuit validity, gate weight, and tensor gate symbol enums across environment helpers to avoid raw integer usage
- migrate random circuit generator logic to use strongly typed gate symbols and index helpers throughout

## Testing
- cmake -S . -B build *(fails: missing MLIR package in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ef6fe3d22483328e7168be42a632e0