### PR TITLE
Track pass application state across MQSS optimization passes

### DIFF
--- a/lib/Passes/Cancellations/CxCxToId.cpp
+++ b/lib/Passes/Cancellations/CxCxToId.cpp
@@ -21,7 +21,7 @@ using namespace mqss::support::transforms;
 
 namespace {
 
-class CxCxToId final : public BaseMQSSPass<CxCxToId> {
+class CxCxToId final : public BaseMQSSPass<CxCxToId>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(CxCxToId)
 
@@ -32,6 +32,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto cxOp2 = dyn_cast_or_null<quake::XOp>(*op);
       if (!cxOp2
@@ -60,6 +61,7 @@ public:
       IRRewriter rewriter(cxOp2->getContext());
       rewriter.eraseOp(cxOp2);
       rewriter.eraseOp(cxOp1);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Cancellations/CyCyToId.cpp
+++ b/lib/Passes/Cancellations/CyCyToId.cpp
@@ -19,7 +19,7 @@ using namespace mqss::support::transforms;
 
 namespace {
 
-class CyCyToId final : public BaseMQSSPass<CyCyToId> {
+class CyCyToId final : public BaseMQSSPass<CyCyToId>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(CyCyToId)
 
@@ -30,6 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto cyOp2 = dyn_cast_or_null<quake::YOp>(*op);
       if (!cyOp2
@@ -58,6 +59,7 @@ public:
       IRRewriter rewriter(cyOp2->getContext());
       rewriter.eraseOp(cyOp2);
       rewriter.eraseOp(cyOp1);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Cancellations/CzCzToId.cpp
+++ b/lib/Passes/Cancellations/CzCzToId.cpp
@@ -19,7 +19,7 @@ using namespace mqss::support::transforms;
 
 namespace {
 
-class CzCzToId final : public BaseMQSSPass<CzCzToId> {
+class CzCzToId final : public BaseMQSSPass<CzCzToId>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(CzCzToId)
 
@@ -30,6 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto czOp2 = dyn_cast_or_null<quake::ZOp>(*op);
       if (!czOp2
@@ -58,6 +59,7 @@ public:
       IRRewriter rewriter(czOp2->getContext());
       rewriter.eraseOp(czOp2);
       rewriter.eraseOp(czOp1);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Cancellations/HHToId.cpp
+++ b/lib/Passes/Cancellations/HHToId.cpp
@@ -17,7 +17,7 @@ using namespace mlir;
 using namespace mqss::support::transforms;
 
 namespace {
-class HHToId final : public BaseMQSSPass<HHToId> {
+class HHToId final : public BaseMQSSPass<HHToId>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(HHToId)
 
@@ -28,6 +28,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto hOp2 = dyn_cast_or_null<quake::HOp>(*op);
       if (!hOp2
@@ -49,6 +50,7 @@ public:
       IRRewriter rewriter(hOp2->getContext());
       rewriter.eraseOp(hOp2);
       rewriter.eraseOp(hOp1);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Cancellations/SSdgToId.cpp
+++ b/lib/Passes/Cancellations/SSdgToId.cpp
@@ -19,7 +19,7 @@ using namespace mlir;
 using namespace mqss::support::transforms;
 
 namespace {
-class SSdgToId final : public BaseMQSSPass<SSdgToId> {
+class SSdgToId final : public BaseMQSSPass<SSdgToId>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SSdgToId)
 
@@ -30,6 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto sOp2 = dyn_cast_or_null<quake::SOp>(*op);
       if (!sOp2
@@ -53,6 +54,7 @@ public:
       IRRewriter rewriter(sOp2->getContext());
       rewriter.eraseOp(sOp2);
       rewriter.eraseOp(sOp1);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Cancellations/SdgSToId.cpp
+++ b/lib/Passes/Cancellations/SdgSToId.cpp
@@ -19,7 +19,7 @@ using namespace mlir;
 using namespace mqss::support::transforms;
 
 namespace {
-class SdgSToId final : public BaseMQSSPass<SdgSToId> {
+class SdgSToId final : public BaseMQSSPass<SdgSToId>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SdgSToId)
 
@@ -30,6 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto sOp2 = dyn_cast_or_null<quake::SOp>(*op);
       if (!sOp2
@@ -53,6 +54,7 @@ public:
       IRRewriter rewriter(sOp2->getContext());
       rewriter.eraseOp(sOp2);
       rewriter.eraseOp(sOp1);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Cancellations/TTdgToId.cpp
+++ b/lib/Passes/Cancellations/TTdgToId.cpp
@@ -20,7 +20,7 @@ using namespace mqss::support::transforms;
 
 namespace {
 
-class TTdgToId final : public BaseMQSSPass<TTdgToId> {
+class TTdgToId final : public BaseMQSSPass<TTdgToId>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TTdgToId)
 
@@ -31,6 +31,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto tOp2 = dyn_cast_or_null<quake::TOp>(*op);
       if (!tOp2
@@ -54,6 +55,7 @@ public:
       IRRewriter rewriter(tOp2->getContext());
       rewriter.eraseOp(tOp2);
       rewriter.eraseOp(tOp1);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Cancellations/TdgTToId.cpp
+++ b/lib/Passes/Cancellations/TdgTToId.cpp
@@ -20,7 +20,7 @@ using namespace mqss::support::transforms;
 
 namespace {
 
-class TdgTToId final : public BaseMQSSPass<TdgTToId> {
+class TdgTToId final : public BaseMQSSPass<TdgTToId>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TdgTToId)
 
@@ -31,6 +31,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto tOp2 = dyn_cast_or_null<quake::TOp>(*op);
       if (!tOp2
@@ -54,6 +55,7 @@ public:
       IRRewriter rewriter(tOp2->getContext());
       rewriter.eraseOp(tOp2);
       rewriter.eraseOp(tOp1);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Cancellations/XXToId.cpp
+++ b/lib/Passes/Cancellations/XXToId.cpp
@@ -17,7 +17,7 @@ using namespace mlir;
 using namespace mqss::support::transforms;
 
 namespace {
-class XXToId final : public BaseMQSSPass<XXToId> {
+class XXToId final : public BaseMQSSPass<XXToId>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(XXToId)
 
@@ -28,6 +28,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto xOp2 = dyn_cast_or_null<quake::XOp>(*op);
       if (!xOp2
@@ -49,6 +50,7 @@ public:
       IRRewriter rewriter(xOp2->getContext());
       rewriter.eraseOp(xOp2);
       rewriter.eraseOp(xOp1);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Cancellations/YYToId.cpp
+++ b/lib/Passes/Cancellations/YYToId.cpp
@@ -16,7 +16,7 @@ using namespace mlir;
 using namespace mqss::support::transforms;
 
 namespace {
-class YYToId final : public BaseMQSSPass<YYToId> {
+class YYToId final : public BaseMQSSPass<YYToId>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(YYToId)
 
@@ -27,6 +27,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto yOp2 = dyn_cast_or_null<quake::YOp>(*op);
       if (!yOp2
@@ -48,6 +49,7 @@ public:
       IRRewriter rewriter(yOp2->getContext());
       rewriter.eraseOp(yOp2);
       rewriter.eraseOp(yOp1);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Cancellations/ZZToId.cpp
+++ b/lib/Passes/Cancellations/ZZToId.cpp
@@ -17,7 +17,7 @@ using namespace mlir;
 using namespace mqss::support::transforms;
 
 namespace {
-class ZZToId final : public BaseMQSSPass<ZZToId> {
+class ZZToId final : public BaseMQSSPass<ZZToId>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ZZToId)
 
@@ -28,6 +28,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto zOp2 = dyn_cast_or_null<quake::ZOp>(*op);
       if (!zOp2
@@ -49,6 +50,7 @@ public:
       IRRewriter rewriter(zOp2->getContext());
       rewriter.eraseOp(zOp2);
       rewriter.eraseOp(zOp1);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Cancellations/ZeroRyToId.cpp
+++ b/lib/Passes/Cancellations/ZeroRyToId.cpp
@@ -23,7 +23,7 @@ using namespace mqss::support::transforms;
 
 namespace {
 
-class ZeroRyToId final : public BaseMQSSPass<ZeroRyToId> {
+class ZeroRyToId final : public BaseMQSSPass<ZeroRyToId>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ZeroRyToId)
 
@@ -34,6 +34,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto ryOp = dyn_cast_or_null<quake::RyOp>(*op);
       if (!ryOp
@@ -50,6 +51,7 @@ public:
       if (isMultipleOfTwoPi(params[0])) {
         IRRewriter rewriter(ryOp->getContext());
         rewriter.eraseOp(ryOp);
+        this->wasApplied = true;
       }
     });
   }

--- a/lib/Passes/Cancellations/ZeroRzToId.cpp
+++ b/lib/Passes/Cancellations/ZeroRzToId.cpp
@@ -23,7 +23,7 @@ using namespace mqss::support::transforms;
 
 namespace {
 
-class ZeroRzToId final : public BaseMQSSPass<ZeroRzToId> {
+class ZeroRzToId final : public BaseMQSSPass<ZeroRzToId>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ZeroRzToId)
 
@@ -34,6 +34,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto rzOp = dyn_cast_or_null<quake::RzOp>(*op);
       if (!rzOp
@@ -50,6 +51,7 @@ public:
       if (isMultipleOfTwoPi(params[0])) {
         IRRewriter rewriter(rzOp->getContext());
         rewriter.eraseOp(rzOp);
+        this->wasApplied = true;
       }
     });
   }

--- a/lib/Passes/Decompositions/CrxToHCrzH.cpp
+++ b/lib/Passes/Decompositions/CrxToHCrzH.cpp
@@ -17,7 +17,7 @@ namespace mqss::opt {
 using namespace mlir;
 
 namespace {
-class CrxToHCrzH final : public BaseMQSSPass<CrxToHCrzH> {
+class CrxToHCrzH final : public BaseMQSSPass<CrxToHCrzH>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(CrxToHCrzH)
 
@@ -28,6 +28,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto crxOp = dyn_cast_or_null<quake::RxOp>(*op);
       if (!crxOp
@@ -48,6 +49,7 @@ public:
       rewriter.create<quake::RzOp>(loc, false, param, control, target);
       rewriter.create<quake::HOp>(loc, target);
       rewriter.eraseOp(crxOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Decompositions/CrzToHCrxH.cpp
+++ b/lib/Passes/Decompositions/CrzToHCrxH.cpp
@@ -18,7 +18,7 @@ using namespace mlir;
 
 namespace {
 
-class CrzToHCrxH final : public BaseMQSSPass<CrzToHCrxH> {
+class CrzToHCrxH final : public BaseMQSSPass<CrzToHCrxH>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(CrzToHCrxH)
 
@@ -29,6 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto crzOp = dyn_cast_or_null<quake::RzOp>(*op);
       if (!crzOp
@@ -49,6 +50,7 @@ public:
       rewriter.create<quake::RxOp>(loc, false, param, control, target);
       rewriter.create<quake::HOp>(loc, target);
       rewriter.eraseOp(crzOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Decompositions/CxToLowerHCzH.cpp
+++ b/lib/Passes/Decompositions/CxToLowerHCzH.cpp
@@ -17,7 +17,8 @@ namespace mqss::opt {
 using namespace mlir;
 
 namespace {
-class CxToLowerHCzH final : public BaseMQSSPass<CxToLowerHCzH> {
+class CxToLowerHCzH final : public BaseMQSSPass<CxToLowerHCzH>,
+                             AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(CxToLowerHCzH)
 
@@ -28,6 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto cxOp = dyn_cast_or_null<quake::XOp>(*op);
       if (!cxOp
@@ -45,6 +47,7 @@ public:
       rewriter.create<quake::ZOp>(loc, target, control);
       rewriter.create<quake::HOp>(loc, target);
       rewriter.eraseOp(cxOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Decompositions/CxToUpperHCzH.cpp
+++ b/lib/Passes/Decompositions/CxToUpperHCzH.cpp
@@ -17,7 +17,8 @@ namespace mqss::opt {
 using namespace mlir;
 
 namespace {
-class CxToUpperHCzH final : public BaseMQSSPass<CxToUpperHCzH> {
+class CxToUpperHCzH final : public BaseMQSSPass<CxToUpperHCzH>,
+                             AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(CxToUpperHCzH)
 
@@ -28,6 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto cxOp = dyn_cast_or_null<quake::XOp>(*op);
       if (!cxOp
@@ -45,6 +47,7 @@ public:
       rewriter.create<quake::ZOp>(loc, control, target);
       rewriter.create<quake::HOp>(loc, target);
       rewriter.eraseOp(cxOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Decompositions/CzToLowerHCxH.cpp
+++ b/lib/Passes/Decompositions/CzToLowerHCxH.cpp
@@ -17,7 +17,8 @@ namespace mqss::opt {
 using namespace mlir;
 
 namespace {
-class CzToLowerHCxH final : public BaseMQSSPass<CzToLowerHCxH> {
+class CzToLowerHCxH final : public BaseMQSSPass<CzToLowerHCxH>,
+                             AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(CzToLowerHCxH)
 
@@ -28,6 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto czOp = dyn_cast_or_null<quake::ZOp>(*op);
       if (!czOp
@@ -45,6 +47,7 @@ public:
       rewriter.create<quake::XOp>(loc, target, control);
       rewriter.create<quake::HOp>(loc, control);
       rewriter.eraseOp(czOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Decompositions/CzToUpperHCxH.cpp
+++ b/lib/Passes/Decompositions/CzToUpperHCxH.cpp
@@ -17,7 +17,8 @@ namespace mqss::opt {
 using namespace mlir;
 
 namespace {
-class CzToUpperHCxH final : public BaseMQSSPass<CzToUpperHCxH> {
+class CzToUpperHCxH final : public BaseMQSSPass<CzToUpperHCxH>,
+                             AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(CzToUpperHCxH)
 
@@ -28,6 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto czOp = dyn_cast_or_null<quake::ZOp>(*op);
       if (!czOp
@@ -45,6 +47,7 @@ public:
       rewriter.create<quake::XOp>(loc, control, target);
       rewriter.create<quake::HOp>(loc, target);
       rewriter.eraseOp(czOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Decompositions/ReverseCx.cpp
+++ b/lib/Passes/Decompositions/ReverseCx.cpp
@@ -18,7 +18,7 @@ using namespace mlir;
 
 namespace {
 
-class ReverseCx final : public BaseMQSSPass<ReverseCx> {
+class ReverseCx final : public BaseMQSSPass<ReverseCx>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ReverseCx)
 
@@ -29,6 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto cxOp = dyn_cast_or_null<quake::XOp>(*op);
       if (!cxOp
@@ -48,6 +49,7 @@ public:
       rewriter.create<quake::HOp>(loc, target);
       rewriter.create<quake::HOp>(loc, control);
       rewriter.eraseOp(cxOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Decompositions/RxToHRzH.cpp
+++ b/lib/Passes/Decompositions/RxToHRzH.cpp
@@ -18,7 +18,7 @@ using namespace mlir;
 
 namespace {
 
-class RxToHRzH final : public BaseMQSSPass<RxToHRzH> {
+class RxToHRzH final : public BaseMQSSPass<RxToHRzH>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(RxToHRzH)
 
@@ -29,6 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto rxOp = dyn_cast_or_null<quake::RxOp>(*op);
       if (!rxOp
@@ -48,6 +49,7 @@ public:
       rewriter.create<quake::RzOp>(loc, false, param, ValueRange{}, target);
       rewriter.create<quake::HOp>(loc, target);
       rewriter.eraseOp(rxOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Decompositions/RzToHRxH.cpp
+++ b/lib/Passes/Decompositions/RzToHRxH.cpp
@@ -17,7 +17,7 @@ namespace mqss::opt {
 using namespace mlir;
 
 namespace {
-class RzToHRxH final : public BaseMQSSPass<RzToHRxH> {
+class RzToHRxH final : public BaseMQSSPass<RzToHRxH>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(RzToHRxH)
 
@@ -28,6 +28,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto rzOp = dyn_cast_or_null<quake::RzOp>(*op);
       if (!rzOp
@@ -47,6 +48,7 @@ public:
       rewriter.create<quake::RxOp>(loc, false, param, ValueRange{}, target);
       rewriter.create<quake::HOp>(loc, target);
       rewriter.eraseOp(rzOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Decompositions/SToSdgSdgSdg.cpp
+++ b/lib/Passes/Decompositions/SToSdgSdgSdg.cpp
@@ -17,7 +17,8 @@ namespace mqss::opt {
 using namespace mlir;
 
 namespace {
-class SToSdgSdgSdg final : public BaseMQSSPass<SToSdgSdgSdg> {
+class SToSdgSdgSdg final : public BaseMQSSPass<SToSdgSdgSdg>,
+                             AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SToSdgSdgSdg)
 
@@ -28,6 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto sOp = dyn_cast_or_null<quake::SOp>(*op);
       if (!sOp
@@ -44,6 +46,7 @@ public:
       rewriter.create<quake::SOp>(loc, true, target);
       rewriter.create<quake::SOp>(loc, true, target);
       rewriter.eraseOp(sOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Decompositions/SToTT.cpp
+++ b/lib/Passes/Decompositions/SToTT.cpp
@@ -17,7 +17,7 @@ namespace mqss::opt {
 using namespace mlir;
 
 namespace {
-class SToTT final : public BaseMQSSPass<SToTT> {
+class SToTT final : public BaseMQSSPass<SToTT>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SToTT)
 
@@ -28,6 +28,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto sOp = dyn_cast_or_null<quake::SOp>(*op);
       if (!sOp
@@ -43,6 +44,7 @@ public:
       rewriter.create<quake::TOp>(loc, false, target);
       rewriter.create<quake::TOp>(loc, false, target);
       rewriter.eraseOp(sOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Decompositions/SdgToSSS.cpp
+++ b/lib/Passes/Decompositions/SdgToSSS.cpp
@@ -17,7 +17,7 @@ namespace mqss::opt {
 using namespace mlir;
 
 namespace {
-class SdgToSSS final : public BaseMQSSPass<SdgToSSS> {
+class SdgToSSS final : public BaseMQSSPass<SdgToSSS>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SdgToSSS)
 
@@ -28,6 +28,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto sOp = dyn_cast_or_null<quake::SOp>(*op);
       if (!sOp
@@ -44,6 +45,7 @@ public:
       rewriter.create<quake::SOp>(loc, false, target);
       rewriter.create<quake::SOp>(loc, false, target);
       rewriter.eraseOp(sOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Decompositions/SwapToLowerCxCxCx.cpp
+++ b/lib/Passes/Decompositions/SwapToLowerCxCxCx.cpp
@@ -17,7 +17,8 @@ namespace mqss::opt {
 using namespace mlir;
 
 namespace {
-class SwapToLowerCxCxCx final : public BaseMQSSPass<SwapToLowerCxCxCx> {
+class SwapToLowerCxCxCx final : public BaseMQSSPass<SwapToLowerCxCxCx>,
+                                  AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SwapToLowerCxCxCx)
 
@@ -28,6 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto swapOp = dyn_cast_or_null<quake::SwapOp>(*op);
       if (!swapOp
@@ -44,6 +46,7 @@ public:
       rewriter.create<quake::XOp>(loc, q0, q1);
       rewriter.create<quake::XOp>(loc, q1, q0);
       rewriter.eraseOp(swapOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Decompositions/SwapToUpperCxCxCx.cpp
+++ b/lib/Passes/Decompositions/SwapToUpperCxCxCx.cpp
@@ -18,7 +18,8 @@ using namespace mlir;
 
 namespace {
 
-class SwapToUpperCxCxCx final : public BaseMQSSPass<SwapToUpperCxCxCx> {
+class SwapToUpperCxCxCx final : public BaseMQSSPass<SwapToUpperCxCxCx>,
+                                  AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SwapToUpperCxCxCx)
 
@@ -29,6 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto swapOp = dyn_cast_or_null<quake::SwapOp>(*op);
       if (!swapOp
@@ -45,6 +47,7 @@ public:
       rewriter.create<quake::XOp>(loc, q1, q0);
       rewriter.create<quake::XOp>(loc, q0, q1);
       rewriter.eraseOp(swapOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Decompositions/XToHZH.cpp
+++ b/lib/Passes/Decompositions/XToHZH.cpp
@@ -17,7 +17,7 @@ namespace mqss::opt {
 using namespace mlir;
 
 namespace {
-class XToHZH final : public BaseMQSSPass<XToHZH> {
+class XToHZH final : public BaseMQSSPass<XToHZH>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(XToHZH)
 
@@ -28,6 +28,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto xOp = dyn_cast_or_null<quake::XOp>(*op);
       if (!xOp
@@ -43,6 +44,7 @@ public:
       rewriter.create<quake::ZOp>(loc, false, target);
       rewriter.create<quake::HOp>(loc, false, target);
       rewriter.eraseOp(xOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Decompositions/ZToHXH.cpp
+++ b/lib/Passes/Decompositions/ZToHXH.cpp
@@ -17,7 +17,7 @@ namespace mqss::opt {
 using namespace mlir;
 
 namespace {
-class ZToHXH final : public BaseMQSSPass<ZToHXH> {
+class ZToHXH final : public BaseMQSSPass<ZToHXH>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ZToHXH)
 
@@ -28,6 +28,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto zOp = dyn_cast_or_null<quake::ZOp>(*op);
       if (!zOp
@@ -43,6 +44,7 @@ public:
       rewriter.create<quake::XOp>(loc, false, target);
       rewriter.create<quake::HOp>(loc, false, target);
       rewriter.eraseOp(zOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/CxCxCxToSwap.cpp
+++ b/lib/Passes/Transforms/CxCxCxToSwap.cpp
@@ -20,7 +20,8 @@ using namespace mqss::support::quakeDialect;
 
 namespace {
 
-class CxCxCxToSwap final : public BaseMQSSPass<CxCxCxToSwap> {
+class CxCxCxToSwap final : public BaseMQSSPass<CxCxCxToSwap>,
+                             AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(CxCxCxToSwap)
 
@@ -31,6 +32,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto cxOp3 = dyn_cast_or_null<quake::XOp>(*op);
       if (!cxOp3
@@ -83,6 +85,7 @@ public:
       rewriter.eraseOp(cxOp1);
       rewriter.eraseOp(cxOp2);
       rewriter.eraseOp(cxOp3);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/CxRxToRxCx.cpp
+++ b/lib/Passes/Transforms/CxRxToRxCx.cpp
@@ -19,7 +19,7 @@ using namespace mqss::support::transforms;
 
 namespace {
 
-class CxRxToRxCx final : public BaseMQSSPass<CxRxToRxCx> {
+class CxRxToRxCx final : public BaseMQSSPass<CxRxToRxCx>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(CxRxToRxCx)
 
@@ -30,6 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto rxOp = dyn_cast_or_null<quake::RxOp>(*op);
       if (!rxOp
@@ -61,6 +62,7 @@ public:
       rewriter.create<quake::XOp>(loc, false, ValueRange{}, controls, targets);
       rewriter.eraseOp(cxOp);
       rewriter.eraseOp(rxOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/CxXToXCx.cpp
+++ b/lib/Passes/Transforms/CxXToXCx.cpp
@@ -19,7 +19,7 @@ using namespace mqss::support::transforms;
 
 namespace {
 
-class CxXToXCx final : public BaseMQSSPass<CxXToXCx> {
+class CxXToXCx final : public BaseMQSSPass<CxXToXCx>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(CxXToXCx)
 
@@ -30,6 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto xOp = dyn_cast_or_null<quake::XOp>(*op);
       if (!xOp
@@ -58,6 +59,7 @@ public:
       rewriter.create<quake::XOp>(loc, false, controls, targets);
       rewriter.eraseOp(cxOp);
       rewriter.eraseOp(xOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/CxZToZCx.cpp
+++ b/lib/Passes/Transforms/CxZToZCx.cpp
@@ -19,7 +19,7 @@ using namespace mlir;
 using namespace mqss::support::transforms;
 
 namespace {
-class CxZToZCx final : public BaseMQSSPass<CxZToZCx> {
+class CxZToZCx final : public BaseMQSSPass<CxZToZCx>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(CxZToZCx)
 
@@ -30,6 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto zOp = dyn_cast_or_null<quake::ZOp>(*op);
       if (!zOp
@@ -58,6 +59,7 @@ public:
       rewriter.create<quake::XOp>(loc, false, controls, targets);
       rewriter.eraseOp(cxOp);
       rewriter.eraseOp(zOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/HCrxHToCrz.cpp
+++ b/lib/Passes/Transforms/HCrxHToCrz.cpp
@@ -20,7 +20,7 @@ using namespace mqss::support::transforms;
 
 namespace {
 
-class HCrxHToCrz final : public BaseMQSSPass<HCrxHToCrz> {
+class HCrxHToCrz final : public BaseMQSSPass<HCrxHToCrz>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(HCrxHToCrz)
 
@@ -31,6 +31,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto hOp2 = dyn_cast_or_null<quake::HOp>(*op);
       if (!hOp2
@@ -72,6 +73,7 @@ public:
       rewriter.eraseOp(hOp1);
       rewriter.eraseOp(crxOp);
       rewriter.eraseOp(hOp2);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/HCrzHToCrx.cpp
+++ b/lib/Passes/Transforms/HCrzHToCrx.cpp
@@ -19,7 +19,7 @@ using namespace mlir;
 using namespace mqss::support::transforms;
 
 namespace {
-class HCrzHToCrx final : public BaseMQSSPass<HCrzHToCrx> {
+class HCrzHToCrx final : public BaseMQSSPass<HCrzHToCrx>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(HCrzHToCrx)
 
@@ -30,6 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto hOp2 = dyn_cast_or_null<quake::HOp>(*op);
       if (!hOp2
@@ -71,6 +72,7 @@ public:
       rewriter.eraseOp(hOp1);
       rewriter.eraseOp(crzOp);
       rewriter.eraseOp(hOp2);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/HCxHToCz.cpp
+++ b/lib/Passes/Transforms/HCxHToCz.cpp
@@ -19,7 +19,7 @@ using namespace mlir;
 using namespace mqss::support::transforms;
 
 namespace {
-class HCxHToCz final : public BaseMQSSPass<HCxHToCz> {
+class HCxHToCz final : public BaseMQSSPass<HCxHToCz>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(HCxHToCz)
 
@@ -30,6 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto hOp2 = dyn_cast_or_null<quake::HOp>(*op);
       if (!hOp2
@@ -68,6 +69,7 @@ public:
       rewriter.eraseOp(hOp1);
       rewriter.eraseOp(cxOp);
       rewriter.eraseOp(hOp2);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/HCzHToCx.cpp
+++ b/lib/Passes/Transforms/HCzHToCx.cpp
@@ -19,7 +19,7 @@ using namespace mlir;
 using namespace mqss::support::transforms;
 
 namespace {
-class HCzHToCx final : public BaseMQSSPass<HCzHToCx> {
+class HCzHToCx final : public BaseMQSSPass<HCzHToCx>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(HCzHToCx)
 
@@ -30,6 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto hOp2 = dyn_cast_or_null<quake::HOp>(*op);
       if (!hOp2
@@ -68,6 +69,7 @@ public:
       rewriter.eraseOp(hOp1);
       rewriter.eraseOp(czOp);
       rewriter.eraseOp(hOp2);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/HRxHToRz.cpp
+++ b/lib/Passes/Transforms/HRxHToRz.cpp
@@ -19,7 +19,7 @@ using namespace mlir;
 using namespace mqss::support::transforms;
 
 namespace {
-class HRxHToRz final : public BaseMQSSPass<HRxHToRz> {
+class HRxHToRz final : public BaseMQSSPass<HRxHToRz>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(HRxHToRz)
 
@@ -30,6 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto hOp2 = dyn_cast_or_null<quake::HOp>(*op);
       if (!hOp2
@@ -70,6 +71,7 @@ public:
       rewriter.eraseOp(hOp1);
       rewriter.eraseOp(rxOp);
       rewriter.eraseOp(hOp2);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/HRzHToRx.cpp
+++ b/lib/Passes/Transforms/HRzHToRx.cpp
@@ -19,7 +19,7 @@ using namespace mlir;
 using namespace mqss::support::transforms;
 
 namespace {
-class HRzHToRx final : public BaseMQSSPass<HRzHToRx> {
+class HRzHToRx final : public BaseMQSSPass<HRzHToRx>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(HRzHToRx)
 
@@ -30,6 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto hOp2 = dyn_cast_or_null<quake::HOp>(*op);
       if (!hOp2
@@ -71,6 +72,7 @@ public:
       rewriter.eraseOp(hOp1);
       rewriter.eraseOp(rzOp);
       rewriter.eraseOp(hOp2);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/HXHToZ.cpp
+++ b/lib/Passes/Transforms/HXHToZ.cpp
@@ -19,7 +19,7 @@ using namespace mlir;
 using namespace mqss::support::transforms;
 
 namespace {
-class HXHToZ final : public BaseMQSSPass<HXHToZ> {
+class HXHToZ final : public BaseMQSSPass<HXHToZ>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(HXHToZ)
 
@@ -30,6 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto hOp2 = dyn_cast_or_null<quake::HOp>(*op);
       if (!hOp2
@@ -67,6 +68,7 @@ public:
       rewriter.eraseOp(hOp1);
       rewriter.eraseOp(xOp);
       rewriter.eraseOp(hOp2);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/HXToZH.cpp
+++ b/lib/Passes/Transforms/HXToZH.cpp
@@ -18,7 +18,7 @@ using namespace mqss::support::transforms;
 
 namespace {
 
-class HXToZH final : public BaseMQSSPass<HXToZH> {
+class HXToZH final : public BaseMQSSPass<HXToZH>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(HXToZH)
 
@@ -29,6 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto xOp = dyn_cast_or_null<quake::XOp>(*op);
       if (!xOp
@@ -55,6 +56,7 @@ public:
       rewriter.create<quake::HOp>(loc, false, targets);
       rewriter.eraseOp(hOp);
       rewriter.eraseOp(xOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/HYToYH.cpp
+++ b/lib/Passes/Transforms/HYToYH.cpp
@@ -17,7 +17,7 @@ using namespace mlir;
 using namespace mqss::support::transforms;
 
 namespace {
-class HYToYH final : public BaseMQSSPass<HYToYH> {
+class HYToYH final : public BaseMQSSPass<HYToYH>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(HYToYH)
   StringRef getArgument() const override { return "HYToYH"; }
@@ -28,6 +28,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto yOp = dyn_cast_or_null<quake::YOp>(*op);
       if (!yOp
@@ -54,6 +55,7 @@ public:
       rewriter.create<quake::HOp>(loc, false, targets);
       rewriter.eraseOp(hOp);
       rewriter.eraseOp(yOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/HZHToX.cpp
+++ b/lib/Passes/Transforms/HZHToX.cpp
@@ -19,7 +19,7 @@ using namespace mlir;
 using namespace mqss::support::transforms;
 
 namespace {
-class HZHToX final : public BaseMQSSPass<HZHToX> {
+class HZHToX final : public BaseMQSSPass<HZHToX>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(HZHToX)
 
@@ -30,6 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto hOp2 = dyn_cast_or_null<quake::HOp>(*op);
       if (!hOp2
@@ -67,6 +68,7 @@ public:
       rewriter.eraseOp(hOp1);
       rewriter.eraseOp(zOp);
       rewriter.eraseOp(hOp2);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/HZToXH.cpp
+++ b/lib/Passes/Transforms/HZToXH.cpp
@@ -18,7 +18,7 @@ using namespace mqss::support::transforms;
 
 namespace {
 
-class HZToXH final : public BaseMQSSPass<HZToXH> {
+class HZToXH final : public BaseMQSSPass<HZToXH>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(HZToXH)
 
@@ -29,6 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto zOp = dyn_cast_or_null<quake::ZOp>(*op);
       if (!zOp
@@ -55,6 +56,7 @@ public:
       rewriter.create<quake::HOp>(loc, false, targets);
       rewriter.eraseOp(hOp);
       rewriter.eraseOp(zOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/NormalizeArgAngle.cpp
+++ b/lib/Passes/Transforms/NormalizeArgAngle.cpp
@@ -45,10 +45,10 @@ using namespace mqss::support::quakeDialect;
 
 namespace {
 
-void normalizeAngleOfRotations(Operation *currentOp, OpBuilder builder) {
+bool normalizeAngleOfRotations(Operation *currentOp, OpBuilder builder) {
   if (!isa<quake::RxOp>(currentOp) && !isa<quake::RyOp>(currentOp) &&
       !isa<quake::RzOp>(currentOp))
-    return; // do nothing if it is not rotation
+    return false; // do nothing if it is not rotation
   auto gate = dyn_cast<quake::OperatorInterface>(currentOp);
   double pi = std::numbers::pi;
   std::vector<Value> nParameters = {};
@@ -57,7 +57,7 @@ void normalizeAngleOfRotations(Operation *currentOp, OpBuilder builder) {
     auto optional_param_value
         = extractDoubleArgumentValue(parameter.getDefiningOp());
     if (!optional_param_value.has_value()) {
-      return;
+      return false;
     }
     double param = optional_param_value.value();
     param =
@@ -81,9 +81,11 @@ void normalizeAngleOfRotations(Operation *currentOp, OpBuilder builder) {
         normParameters, gate.getControls(), gate.getTargets());
   }
   rewriter.eraseOp(gate);
+  return true;
 }
 
-class NormalizeArgAngle final : public BaseMQSSPass<NormalizeArgAngle> {
+class NormalizeArgAngle final : public BaseMQSSPass<NormalizeArgAngle>,
+                                AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(NormalizeArgAngle)
 
@@ -94,8 +96,12 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     OpBuilder builder(&kernel.getBody());
-    kernel.walk([&](Operation *op) { normalizeAngleOfRotations(op, builder); });
+    kernel.walk([&](Operation *op) {
+      if (normalizeAngleOfRotations(op, builder))
+        this->wasApplied = true;
+    });
   }
 };
 } // namespace

--- a/lib/Passes/Transforms/QuakeQMap.cpp
+++ b/lib/Passes/Transforms/QuakeQMap.cpp
@@ -30,6 +30,7 @@ correctly mapped to a given quantum device (Architecture) according to the
 mapping configurations.
 ******************************************************************************/
 
+#include "Passes/BaseMQSSPass.hpp"
 #include "Passes/Transforms.hpp"
 #include "Support/mlir_utils.hpp"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
@@ -222,8 +223,8 @@ void loadMeasurementsToQC(Operation *op, qc::QuantumComputation &qc,
 
 namespace {
 
-class QuakeQMap final : public PassWrapper<
-      QuakeQMap, OperationPass<FuncOp> > {
+class QuakeQMap final
+    : public PassWrapper<QuakeQMap, OperationPass<FuncOp>>, AppliedCheckPass {
   Architecture &architecture;
   const Configuration &settings;
 
@@ -246,6 +247,7 @@ public:
   void runOnOperation()
 
   override {
+    this->wasApplied = false;
     // Getting the function
     auto circuit = getOperation();
     // Get the function name
@@ -253,6 +255,8 @@ public:
     if (funcName.find(std::string(CUDAQ_PREFIX_FUNCTION))
         == std::string::npos)
       return; // do nothing if the function is not cudaq kernel
+
+    this->wasApplied = true;
 
     std::map<int, int> measurements; // key: qubit, value register index
     int numQubits = getNumberOfQubits(circuit);

--- a/lib/Passes/Transforms/RxCxToCxRx.cpp
+++ b/lib/Passes/Transforms/RxCxToCxRx.cpp
@@ -19,7 +19,7 @@ using namespace mqss::support::transforms;
 
 namespace {
 
-class RxCxToCxRx final : public BaseMQSSPass<RxCxToCxRx> {
+class RxCxToCxRx final : public BaseMQSSPass<RxCxToCxRx>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(RxCxToCxRx)
 
@@ -30,6 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto cxOp = dyn_cast_or_null<quake::XOp>(*op);
       if (!cxOp
@@ -59,6 +60,7 @@ public:
       rewriter.create<quake::RxOp>(loc, parameters, ValueRange{}, targets);
       rewriter.eraseOp(rxOp);
       rewriter.eraseOp(cxOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/RxRxToRx.cpp
+++ b/lib/Passes/Transforms/RxRxToRx.cpp
@@ -18,7 +18,7 @@ using namespace mlir;
 using namespace mqss::support::transforms;
 
 namespace {
-class RxRxToRx final : public BaseMQSSPass<RxRxToRx> {
+class RxRxToRx final : public BaseMQSSPass<RxRxToRx>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(RxRxToRx)
 
@@ -29,6 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto rxOp2 = dyn_cast_or_null<quake::RxOp>(*op);
       if (!rxOp2
@@ -63,6 +64,7 @@ public:
       rewriter.create<quake::RxOp>(loc, params, ValueRange{}, targets);
       rewriter.eraseOp(rxOp1);
       rewriter.eraseOp(rxOp2);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/RyRyToRy.cpp
+++ b/lib/Passes/Transforms/RyRyToRy.cpp
@@ -16,7 +16,7 @@ using namespace mlir;
 using namespace mqss::support::transforms;
 
 namespace {
-class RyRyToRy final : public BaseMQSSPass<RyRyToRy> {
+class RyRyToRy final : public BaseMQSSPass<RyRyToRy>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(RyRyToRy)
 
@@ -27,6 +27,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto ryOp2 = dyn_cast_or_null<quake::RyOp>(*op);
       if (!ryOp2
@@ -61,6 +62,7 @@ public:
       rewriter.create<quake::RyOp>(loc, false, params, ValueRange{}, targets);
       rewriter.eraseOp(ryOp1);
       rewriter.eraseOp(ryOp2);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/RzRzToRz.cpp
+++ b/lib/Passes/Transforms/RzRzToRz.cpp
@@ -18,7 +18,7 @@ using namespace mlir;
 using namespace mqss::support::transforms;
 
 namespace {
-class RzRzToRz final : public BaseMQSSPass<RzRzToRz> {
+class RzRzToRz final : public BaseMQSSPass<RzRzToRz>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(RzRzToRz)
 
@@ -29,6 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto rzOp2 = dyn_cast_or_null<quake::RzOp>(*op);
       if (!rzOp2
@@ -63,6 +64,7 @@ public:
       rewriter.create<quake::RzOp>(loc, params, ValueRange{}, targets);
       rewriter.eraseOp(rzOp1);
       rewriter.eraseOp(rzOp2);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/SSSToSdg.cpp
+++ b/lib/Passes/Transforms/SSSToSdg.cpp
@@ -19,7 +19,7 @@ using namespace mlir;
 using namespace mqss::support::transforms;
 
 namespace {
-class SSSToSDG final : public BaseMQSSPass<SSSToSDG> {
+class SSSToSDG final : public BaseMQSSPass<SSSToSDG>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SSSToSDG)
 
@@ -30,6 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto sOp3 = dyn_cast_or_null<quake::SOp>(*op);
       if (!sOp3
@@ -70,6 +71,7 @@ public:
       rewriter.eraseOp(sOp1);
       rewriter.eraseOp(sOp2);
       rewriter.eraseOp(sOp3);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/SSToZ.cpp
+++ b/lib/Passes/Transforms/SSToZ.cpp
@@ -21,7 +21,7 @@ using namespace mqss::support::transforms;
 
 
 namespace {
-class SSToZ final : public BaseMQSSPass<SSToZ> {
+class SSToZ final : public BaseMQSSPass<SSToZ>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SSToZ)
 
@@ -30,6 +30,7 @@ public:
   StringRef getDescription() const override { return "Replace S S by Z"; }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto sOp2 = dyn_cast_or_null<quake::SOp>(*op);
       if (!sOp2
@@ -57,6 +58,7 @@ public:
       rewriter.create<quake::ZOp>(loc, false, targets);
       rewriter.eraseOp(sOp1);
       rewriter.eraseOp(sOp2);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/SZToSdg.cpp
+++ b/lib/Passes/Transforms/SZToSdg.cpp
@@ -19,7 +19,7 @@ using namespace mqss::support::transforms;
 
 namespace {
 
-class SZToSdg final : public BaseMQSSPass<SZToSdg> {
+class SZToSdg final : public BaseMQSSPass<SZToSdg>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SZToSdg)
 
@@ -30,6 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto zOp = dyn_cast_or_null<quake::ZOp>(*op);
       if (!zOp
@@ -56,6 +57,7 @@ public:
       rewriter.create<quake::SOp>(loc, true, targets);
       rewriter.eraseOp(sOp);
       rewriter.eraseOp(zOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/SdgSdgSdgToS.cpp
+++ b/lib/Passes/Transforms/SdgSdgSdgToS.cpp
@@ -20,7 +20,8 @@ using namespace mqss::support::transforms;
 
 namespace {
 
-class SdgSdgSdgToS final : public BaseMQSSPass<SdgSdgSdgToS> {
+class SdgSdgSdgToS final : public BaseMQSSPass<SdgSdgSdgToS>,
+                             AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SdgSdgSdgToS)
 
@@ -31,6 +32,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto sOp3 = dyn_cast_or_null<quake::SOp>(*op);
       if (!sOp3
@@ -71,6 +73,7 @@ public:
       rewriter.eraseOp(sOp1);
       rewriter.eraseOp(sOp2);
       rewriter.eraseOp(sOp3);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/SdgSdgToZ.cpp
+++ b/lib/Passes/Transforms/SdgSdgToZ.cpp
@@ -18,7 +18,7 @@ using namespace mlir;
 using namespace mqss::support::transforms;
 
 namespace {
-class SdgSdgToZ final : public BaseMQSSPass<SdgSdgToZ> {
+class SdgSdgToZ final : public BaseMQSSPass<SdgSdgToZ>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SdgSdgToZ)
 
@@ -29,6 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto sOp2 = dyn_cast_or_null<quake::SOp>(*op);
       if (!sOp2
@@ -56,6 +57,7 @@ public:
       rewriter.create<quake::ZOp>(loc, false, targets);
       rewriter.eraseOp(sOp1);
       rewriter.eraseOp(sOp2);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/SdgZToS.cpp
+++ b/lib/Passes/Transforms/SdgZToS.cpp
@@ -18,7 +18,7 @@ using namespace mlir;
 using namespace mqss::support::transforms;
 
 namespace {
-class SdgZToS final : public BaseMQSSPass<SdgZToS> {
+class SdgZToS final : public BaseMQSSPass<SdgZToS>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SdgZToS)
 
@@ -30,6 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto zOp = dyn_cast_or_null<quake::ZOp>(*op);
       if (!zOp
@@ -56,6 +57,7 @@ public:
       rewriter.create<quake::SOp>(loc, false, targets);
       rewriter.eraseOp(sOp);
       rewriter.eraseOp(zOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/TTToS.cpp
+++ b/lib/Passes/Transforms/TTToS.cpp
@@ -19,7 +19,7 @@ using namespace mqss::support::transforms;
 
 namespace {
 
-class TTToS final : public BaseMQSSPass<TTToS> {
+class TTToS final : public BaseMQSSPass<TTToS>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TTToS)
 
@@ -28,6 +28,7 @@ public:
   StringRef getDescription() const override { return "Replace T T by S"; }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto tOp2 = dyn_cast_or_null<quake::TOp>(*op);
       if (!tOp2
@@ -55,6 +56,7 @@ public:
       rewriter.create<quake::SOp>(loc, false, targets);
       rewriter.eraseOp(tOp1);
       rewriter.eraseOp(tOp2);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/XCxToCxX.cpp
+++ b/lib/Passes/Transforms/XCxToCxX.cpp
@@ -18,7 +18,7 @@ using namespace mqss::support::transforms;
 
 namespace {
 
-class XCxToCxX final : public BaseMQSSPass<XCxToCxX> {
+class XCxToCxX final : public BaseMQSSPass<XCxToCxX>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(XCxToCxX)
 
@@ -29,6 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto cxOp = dyn_cast_or_null<quake::XOp>(*op);
       if (!cxOp
@@ -56,6 +57,7 @@ public:
       rewriter.create<quake::XOp>(loc, false, targets);
       rewriter.eraseOp(xOp);
       rewriter.eraseOp(cxOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/XHToHZ.cpp
+++ b/lib/Passes/Transforms/XHToHZ.cpp
@@ -17,7 +17,7 @@ using namespace mqss::support::transforms;
 
 namespace {
 
-class XHToHZ final : public BaseMQSSPass<XHToHZ> {
+class XHToHZ final : public BaseMQSSPass<XHToHZ>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(XHToHZ)
 
@@ -28,6 +28,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto hOp = dyn_cast_or_null<quake::HOp>(*op);
       if (!hOp
@@ -54,6 +55,7 @@ public:
       rewriter.create<quake::ZOp>(loc, false, targets);
       rewriter.eraseOp(xOp);
       rewriter.eraseOp(hOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/XHZToH.cpp
+++ b/lib/Passes/Transforms/XHZToH.cpp
@@ -18,7 +18,7 @@ using namespace mlir;
 using namespace mqss::support::transforms;
 
 namespace {
-class XHZToH final : public BaseMQSSPass<XHZToH> {
+class XHZToH final : public BaseMQSSPass<XHZToH>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(XHZToH)
 
@@ -29,6 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto zOp = dyn_cast_or_null<quake::ZOp>(*op);
       if (!zOp
@@ -66,6 +67,7 @@ public:
       rewriter.eraseOp(xOp);
       rewriter.eraseOp(hOp);
       rewriter.eraseOp(zOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/YHToHY.cpp
+++ b/lib/Passes/Transforms/YHToHY.cpp
@@ -17,7 +17,7 @@ using namespace mlir;
 using namespace mqss::support::transforms;
 
 namespace {
-class YHToHY final : public BaseMQSSPass<YHToHY> {
+class YHToHY final : public BaseMQSSPass<YHToHY>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(YHToHY)
   StringRef getArgument() const override { return "YHToHY"; }
@@ -27,6 +27,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto hOp = dyn_cast_or_null<quake::HOp>(*op);
       if (!hOp
@@ -53,6 +54,7 @@ public:
       rewriter.create<quake::YOp>(loc, false, target);
       rewriter.eraseOp(yOp);
       rewriter.eraseOp(hOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/ZCxToCxZ.cpp
+++ b/lib/Passes/Transforms/ZCxToCxZ.cpp
@@ -19,7 +19,7 @@ using namespace mqss::support::transforms;
 
 
 namespace {
-class ZCxToCxZ final : public BaseMQSSPass<ZCxToCxZ> {
+class ZCxToCxZ final : public BaseMQSSPass<ZCxToCxZ>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ZCxToCxZ)
 
@@ -30,6 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto cxOp = dyn_cast_or_null<quake::XOp>(*op);
       if (!cxOp
@@ -58,6 +59,7 @@ public:
       rewriter.create<quake::ZOp>(loc, false, controls);
       rewriter.eraseOp(zOp);
       rewriter.eraseOp(cxOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/ZHToHX.cpp
+++ b/lib/Passes/Transforms/ZHToHX.cpp
@@ -17,7 +17,7 @@ using namespace mlir;
 using namespace mqss::support::transforms;
 
 namespace {
-class ZHToHX final : public BaseMQSSPass<ZHToHX> {
+class ZHToHX final : public BaseMQSSPass<ZHToHX>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ZHToHX)
 
@@ -29,6 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto hOp = dyn_cast_or_null<quake::HOp>(*op);
       if (!hOp
@@ -55,6 +56,7 @@ public:
       rewriter.create<quake::XOp>(loc, false, target);
       rewriter.eraseOp(zOp);
       rewriter.eraseOp(hOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/ZHXToH.cpp
+++ b/lib/Passes/Transforms/ZHXToH.cpp
@@ -18,7 +18,7 @@ using namespace mlir;
 using namespace mqss::support::transforms;
 
 namespace {
-class ZHXToH final : public BaseMQSSPass<ZHXToH> {
+class ZHXToH final : public BaseMQSSPass<ZHXToH>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ZHXToH)
 
@@ -27,6 +27,7 @@ public:
   StringRef getDescription() const override { return "Fold Z H X to H"; }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto xOp = dyn_cast_or_null<quake::XOp>(*op);
       if (!xOp
@@ -64,6 +65,7 @@ public:
       rewriter.eraseOp(zOp);
       rewriter.eraseOp(hOp);
       rewriter.eraseOp(xOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/ZSToSdg.cpp
+++ b/lib/Passes/Transforms/ZSToSdg.cpp
@@ -19,7 +19,7 @@ using namespace mqss::support::transforms;
 
 namespace {
 
-class ZSToSdg final : public BaseMQSSPass<ZSToSdg> {
+class ZSToSdg final : public BaseMQSSPass<ZSToSdg>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ZSToSdg)
 
@@ -30,6 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto sOp = dyn_cast_or_null<quake::SOp>(*op);
       if (!sOp
@@ -56,6 +57,7 @@ public:
       rewriter.create<quake::SOp>(loc, true, target);
       rewriter.eraseOp(zOp);
       rewriter.eraseOp(sOp);
+      this->wasApplied = true;
     });
   }
 };

--- a/lib/Passes/Transforms/ZSdgToS.cpp
+++ b/lib/Passes/Transforms/ZSdgToS.cpp
@@ -17,7 +17,7 @@ namespace mqss::opt {
 using namespace mlir;
 
 namespace {
-class ZSdgToS final : public BaseMQSSPass<ZSdgToS> {
+class ZSdgToS final : public BaseMQSSPass<ZSdgToS>, AppliedCheckPass {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ZSdgToS)
 
@@ -28,6 +28,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
+    this->wasApplied = false;
     kernel.walk([&](Operation *op) {
       auto sOp = dyn_cast_or_null<quake::SOp>(*op);
       if (!sOp
@@ -54,6 +55,7 @@ public:
       rewriter.create<quake::SOp>(loc, false, target);
       rewriter.eraseOp(zOp);
       rewriter.eraseOp(sOp);
+      this->wasApplied = true;
     });
   }
 };


### PR DESCRIPTION
## Summary
- extend every cancellation, decomposition, and transform pass to inherit from `AppliedCheckPass`
- reset `wasApplied` when visiting each kernel and set it to true once a transformation rewrites the IR, including the normalize-angle helper and the QuakeQMap pass

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f32eb16b0883328c43947578135961