### PR TITLE
Update wasApplied flag handling

### DIFF
--- a/lib/Passes/Cancellations/CxCxToId.cpp
+++ b/lib/Passes/Cancellations/CxCxToId.cpp
@@ -32,7 +32,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto cxOp2 = dyn_cast_or_null<quake::XOp>(*op);
       if (!cxOp2
@@ -61,7 +61,7 @@ public:
       IRRewriter rewriter(cxOp2->getContext());
       rewriter.eraseOp(cxOp2);
       rewriter.eraseOp(cxOp1);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Cancellations/CyCyToId.cpp
+++ b/lib/Passes/Cancellations/CyCyToId.cpp
@@ -30,7 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto cyOp2 = dyn_cast_or_null<quake::YOp>(*op);
       if (!cyOp2
@@ -59,7 +59,7 @@ public:
       IRRewriter rewriter(cyOp2->getContext());
       rewriter.eraseOp(cyOp2);
       rewriter.eraseOp(cyOp1);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Cancellations/CzCzToId.cpp
+++ b/lib/Passes/Cancellations/CzCzToId.cpp
@@ -30,7 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto czOp2 = dyn_cast_or_null<quake::ZOp>(*op);
       if (!czOp2
@@ -59,7 +59,7 @@ public:
       IRRewriter rewriter(czOp2->getContext());
       rewriter.eraseOp(czOp2);
       rewriter.eraseOp(czOp1);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Cancellations/HHToId.cpp
+++ b/lib/Passes/Cancellations/HHToId.cpp
@@ -28,7 +28,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto hOp2 = dyn_cast_or_null<quake::HOp>(*op);
       if (!hOp2
@@ -50,7 +50,7 @@ public:
       IRRewriter rewriter(hOp2->getContext());
       rewriter.eraseOp(hOp2);
       rewriter.eraseOp(hOp1);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Cancellations/SSdgToId.cpp
+++ b/lib/Passes/Cancellations/SSdgToId.cpp
@@ -30,7 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto sOp2 = dyn_cast_or_null<quake::SOp>(*op);
       if (!sOp2
@@ -54,7 +54,7 @@ public:
       IRRewriter rewriter(sOp2->getContext());
       rewriter.eraseOp(sOp2);
       rewriter.eraseOp(sOp1);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Cancellations/SdgSToId.cpp
+++ b/lib/Passes/Cancellations/SdgSToId.cpp
@@ -30,7 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto sOp2 = dyn_cast_or_null<quake::SOp>(*op);
       if (!sOp2
@@ -54,7 +54,7 @@ public:
       IRRewriter rewriter(sOp2->getContext());
       rewriter.eraseOp(sOp2);
       rewriter.eraseOp(sOp1);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Cancellations/TTdgToId.cpp
+++ b/lib/Passes/Cancellations/TTdgToId.cpp
@@ -31,7 +31,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto tOp2 = dyn_cast_or_null<quake::TOp>(*op);
       if (!tOp2
@@ -55,7 +55,7 @@ public:
       IRRewriter rewriter(tOp2->getContext());
       rewriter.eraseOp(tOp2);
       rewriter.eraseOp(tOp1);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Cancellations/TdgTToId.cpp
+++ b/lib/Passes/Cancellations/TdgTToId.cpp
@@ -31,7 +31,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto tOp2 = dyn_cast_or_null<quake::TOp>(*op);
       if (!tOp2
@@ -55,7 +55,7 @@ public:
       IRRewriter rewriter(tOp2->getContext());
       rewriter.eraseOp(tOp2);
       rewriter.eraseOp(tOp1);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Cancellations/YYToId.cpp
+++ b/lib/Passes/Cancellations/YYToId.cpp
@@ -27,7 +27,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto yOp2 = dyn_cast_or_null<quake::YOp>(*op);
       if (!yOp2
@@ -49,7 +49,7 @@ public:
       IRRewriter rewriter(yOp2->getContext());
       rewriter.eraseOp(yOp2);
       rewriter.eraseOp(yOp1);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Cancellations/ZZToId.cpp
+++ b/lib/Passes/Cancellations/ZZToId.cpp
@@ -28,7 +28,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto zOp2 = dyn_cast_or_null<quake::ZOp>(*op);
       if (!zOp2
@@ -50,7 +50,7 @@ public:
       IRRewriter rewriter(zOp2->getContext());
       rewriter.eraseOp(zOp2);
       rewriter.eraseOp(zOp1);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Cancellations/ZeroRxToId.cpp
+++ b/lib/Passes/Cancellations/ZeroRxToId.cpp
@@ -33,7 +33,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto rxOp = dyn_cast_or_null<quake::RxOp>(*op);
       if (!rxOp || rxOp.getTargets().size() != 1 ||
@@ -48,7 +48,7 @@ public:
       if (isMultipleOfTwoPi(params[0])) {
         IRRewriter rewriter(rxOp->getContext());
         rewriter.eraseOp(rxOp);
-        this->wasApplied = true;
+        this->wasApplied->store(true);
       }
     });
   }

--- a/lib/Passes/Cancellations/ZeroRyToId.cpp
+++ b/lib/Passes/Cancellations/ZeroRyToId.cpp
@@ -34,7 +34,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto ryOp = dyn_cast_or_null<quake::RyOp>(*op);
       if (!ryOp
@@ -51,7 +51,7 @@ public:
       if (isMultipleOfTwoPi(params[0])) {
         IRRewriter rewriter(ryOp->getContext());
         rewriter.eraseOp(ryOp);
-        this->wasApplied = true;
+        this->wasApplied->store(true);
       }
     });
   }

--- a/lib/Passes/Cancellations/ZeroRzToId.cpp
+++ b/lib/Passes/Cancellations/ZeroRzToId.cpp
@@ -34,7 +34,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto rzOp = dyn_cast_or_null<quake::RzOp>(*op);
       if (!rzOp
@@ -51,7 +51,7 @@ public:
       if (isMultipleOfTwoPi(params[0])) {
         IRRewriter rewriter(rzOp->getContext());
         rewriter.eraseOp(rzOp);
-        this->wasApplied = true;
+        this->wasApplied->store(true);
       }
     });
   }

--- a/lib/Passes/Decompositions/CrxToHCrzH.cpp
+++ b/lib/Passes/Decompositions/CrxToHCrzH.cpp
@@ -28,7 +28,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto crxOp = dyn_cast_or_null<quake::RxOp>(*op);
       if (!crxOp
@@ -49,7 +49,7 @@ public:
       rewriter.create<quake::RzOp>(loc, false, param, control, target);
       rewriter.create<quake::HOp>(loc, target);
       rewriter.eraseOp(crxOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Decompositions/CrzToHCrxH.cpp
+++ b/lib/Passes/Decompositions/CrzToHCrxH.cpp
@@ -29,7 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto crzOp = dyn_cast_or_null<quake::RzOp>(*op);
       if (!crzOp
@@ -50,7 +50,7 @@ public:
       rewriter.create<quake::RxOp>(loc, false, param, control, target);
       rewriter.create<quake::HOp>(loc, target);
       rewriter.eraseOp(crzOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Decompositions/CxToLowerHCzH.cpp
+++ b/lib/Passes/Decompositions/CxToLowerHCzH.cpp
@@ -29,7 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto cxOp = dyn_cast_or_null<quake::XOp>(*op);
       if (!cxOp
@@ -47,7 +47,7 @@ public:
       rewriter.create<quake::ZOp>(loc, target, control);
       rewriter.create<quake::HOp>(loc, target);
       rewriter.eraseOp(cxOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Decompositions/CxToUpperHCzH.cpp
+++ b/lib/Passes/Decompositions/CxToUpperHCzH.cpp
@@ -29,7 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto cxOp = dyn_cast_or_null<quake::XOp>(*op);
       if (!cxOp
@@ -47,7 +47,7 @@ public:
       rewriter.create<quake::ZOp>(loc, control, target);
       rewriter.create<quake::HOp>(loc, target);
       rewriter.eraseOp(cxOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Decompositions/CzToLowerHCxH.cpp
+++ b/lib/Passes/Decompositions/CzToLowerHCxH.cpp
@@ -29,7 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto czOp = dyn_cast_or_null<quake::ZOp>(*op);
       if (!czOp
@@ -47,7 +47,7 @@ public:
       rewriter.create<quake::XOp>(loc, target, control);
       rewriter.create<quake::HOp>(loc, control);
       rewriter.eraseOp(czOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Decompositions/CzToUpperHCxH.cpp
+++ b/lib/Passes/Decompositions/CzToUpperHCxH.cpp
@@ -29,7 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto czOp = dyn_cast_or_null<quake::ZOp>(*op);
       if (!czOp
@@ -47,7 +47,7 @@ public:
       rewriter.create<quake::XOp>(loc, control, target);
       rewriter.create<quake::HOp>(loc, target);
       rewriter.eraseOp(czOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Decompositions/ReverseCx.cpp
+++ b/lib/Passes/Decompositions/ReverseCx.cpp
@@ -29,7 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto cxOp = dyn_cast_or_null<quake::XOp>(*op);
       if (!cxOp
@@ -49,7 +49,7 @@ public:
       rewriter.create<quake::HOp>(loc, target);
       rewriter.create<quake::HOp>(loc, control);
       rewriter.eraseOp(cxOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Decompositions/RxToHRzH.cpp
+++ b/lib/Passes/Decompositions/RxToHRzH.cpp
@@ -29,7 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto rxOp = dyn_cast_or_null<quake::RxOp>(*op);
       if (!rxOp
@@ -49,7 +49,7 @@ public:
       rewriter.create<quake::RzOp>(loc, false, param, ValueRange{}, target);
       rewriter.create<quake::HOp>(loc, target);
       rewriter.eraseOp(rxOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Decompositions/RzToHRxH.cpp
+++ b/lib/Passes/Decompositions/RzToHRxH.cpp
@@ -28,7 +28,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto rzOp = dyn_cast_or_null<quake::RzOp>(*op);
       if (!rzOp
@@ -48,7 +48,7 @@ public:
       rewriter.create<quake::RxOp>(loc, false, param, ValueRange{}, target);
       rewriter.create<quake::HOp>(loc, target);
       rewriter.eraseOp(rzOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Decompositions/SToSdgSdgSdg.cpp
+++ b/lib/Passes/Decompositions/SToSdgSdgSdg.cpp
@@ -29,7 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto sOp = dyn_cast_or_null<quake::SOp>(*op);
       if (!sOp
@@ -46,7 +46,7 @@ public:
       rewriter.create<quake::SOp>(loc, true, target);
       rewriter.create<quake::SOp>(loc, true, target);
       rewriter.eraseOp(sOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Decompositions/SToTT.cpp
+++ b/lib/Passes/Decompositions/SToTT.cpp
@@ -28,7 +28,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto sOp = dyn_cast_or_null<quake::SOp>(*op);
       if (!sOp
@@ -44,7 +44,7 @@ public:
       rewriter.create<quake::TOp>(loc, false, target);
       rewriter.create<quake::TOp>(loc, false, target);
       rewriter.eraseOp(sOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Decompositions/SdgToSSS.cpp
+++ b/lib/Passes/Decompositions/SdgToSSS.cpp
@@ -28,7 +28,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto sOp = dyn_cast_or_null<quake::SOp>(*op);
       if (!sOp
@@ -45,7 +45,7 @@ public:
       rewriter.create<quake::SOp>(loc, false, target);
       rewriter.create<quake::SOp>(loc, false, target);
       rewriter.eraseOp(sOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Decompositions/SwapToLowerCxCxCx.cpp
+++ b/lib/Passes/Decompositions/SwapToLowerCxCxCx.cpp
@@ -29,7 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto swapOp = dyn_cast_or_null<quake::SwapOp>(*op);
       if (!swapOp
@@ -46,7 +46,7 @@ public:
       rewriter.create<quake::XOp>(loc, q0, q1);
       rewriter.create<quake::XOp>(loc, q1, q0);
       rewriter.eraseOp(swapOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Decompositions/SwapToUpperCxCxCx.cpp
+++ b/lib/Passes/Decompositions/SwapToUpperCxCxCx.cpp
@@ -30,7 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto swapOp = dyn_cast_or_null<quake::SwapOp>(*op);
       if (!swapOp
@@ -47,7 +47,7 @@ public:
       rewriter.create<quake::XOp>(loc, q1, q0);
       rewriter.create<quake::XOp>(loc, q0, q1);
       rewriter.eraseOp(swapOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Decompositions/XToHZH.cpp
+++ b/lib/Passes/Decompositions/XToHZH.cpp
@@ -28,7 +28,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto xOp = dyn_cast_or_null<quake::XOp>(*op);
       if (!xOp
@@ -44,7 +44,7 @@ public:
       rewriter.create<quake::ZOp>(loc, false, target);
       rewriter.create<quake::HOp>(loc, false, target);
       rewriter.eraseOp(xOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Decompositions/ZToHXH.cpp
+++ b/lib/Passes/Decompositions/ZToHXH.cpp
@@ -28,7 +28,7 @@ public:
   }
 
   void operationsOnQuantumKernel(func::FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto zOp = dyn_cast_or_null<quake::ZOp>(*op);
       if (!zOp
@@ -44,7 +44,7 @@ public:
       rewriter.create<quake::XOp>(loc, false, target);
       rewriter.create<quake::HOp>(loc, false, target);
       rewriter.eraseOp(zOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/CxCxCxToSwap.cpp
+++ b/lib/Passes/Transforms/CxCxCxToSwap.cpp
@@ -32,7 +32,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto cxOp3 = dyn_cast_or_null<quake::XOp>(*op);
       if (!cxOp3
@@ -85,7 +85,7 @@ public:
       rewriter.eraseOp(cxOp1);
       rewriter.eraseOp(cxOp2);
       rewriter.eraseOp(cxOp3);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/CxRxToRxCx.cpp
+++ b/lib/Passes/Transforms/CxRxToRxCx.cpp
@@ -30,7 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto rxOp = dyn_cast_or_null<quake::RxOp>(*op);
       if (!rxOp
@@ -62,7 +62,7 @@ public:
       rewriter.create<quake::XOp>(loc, false, ValueRange{}, controls, targets);
       rewriter.eraseOp(cxOp);
       rewriter.eraseOp(rxOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/CxXToXCx.cpp
+++ b/lib/Passes/Transforms/CxXToXCx.cpp
@@ -30,7 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto xOp = dyn_cast_or_null<quake::XOp>(*op);
       if (!xOp
@@ -59,7 +59,7 @@ public:
       rewriter.create<quake::XOp>(loc, false, controls, targets);
       rewriter.eraseOp(cxOp);
       rewriter.eraseOp(xOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/CxZToZCx.cpp
+++ b/lib/Passes/Transforms/CxZToZCx.cpp
@@ -30,7 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto zOp = dyn_cast_or_null<quake::ZOp>(*op);
       if (!zOp
@@ -59,7 +59,7 @@ public:
       rewriter.create<quake::XOp>(loc, false, controls, targets);
       rewriter.eraseOp(cxOp);
       rewriter.eraseOp(zOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/HCrxHToCrz.cpp
+++ b/lib/Passes/Transforms/HCrxHToCrz.cpp
@@ -31,7 +31,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto hOp2 = dyn_cast_or_null<quake::HOp>(*op);
       if (!hOp2
@@ -73,7 +73,7 @@ public:
       rewriter.eraseOp(hOp1);
       rewriter.eraseOp(crxOp);
       rewriter.eraseOp(hOp2);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/HCrzHToCrx.cpp
+++ b/lib/Passes/Transforms/HCrzHToCrx.cpp
@@ -30,7 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto hOp2 = dyn_cast_or_null<quake::HOp>(*op);
       if (!hOp2
@@ -72,7 +72,7 @@ public:
       rewriter.eraseOp(hOp1);
       rewriter.eraseOp(crzOp);
       rewriter.eraseOp(hOp2);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/HCxHToCz.cpp
+++ b/lib/Passes/Transforms/HCxHToCz.cpp
@@ -30,7 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto hOp2 = dyn_cast_or_null<quake::HOp>(*op);
       if (!hOp2
@@ -69,7 +69,7 @@ public:
       rewriter.eraseOp(hOp1);
       rewriter.eraseOp(cxOp);
       rewriter.eraseOp(hOp2);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/HCzHToCx.cpp
+++ b/lib/Passes/Transforms/HCzHToCx.cpp
@@ -30,7 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto hOp2 = dyn_cast_or_null<quake::HOp>(*op);
       if (!hOp2
@@ -69,7 +69,7 @@ public:
       rewriter.eraseOp(hOp1);
       rewriter.eraseOp(czOp);
       rewriter.eraseOp(hOp2);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/HRxHToRz.cpp
+++ b/lib/Passes/Transforms/HRxHToRz.cpp
@@ -30,7 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto hOp2 = dyn_cast_or_null<quake::HOp>(*op);
       if (!hOp2
@@ -71,7 +71,7 @@ public:
       rewriter.eraseOp(hOp1);
       rewriter.eraseOp(rxOp);
       rewriter.eraseOp(hOp2);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/HRzHToRx.cpp
+++ b/lib/Passes/Transforms/HRzHToRx.cpp
@@ -30,7 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto hOp2 = dyn_cast_or_null<quake::HOp>(*op);
       if (!hOp2
@@ -72,7 +72,7 @@ public:
       rewriter.eraseOp(hOp1);
       rewriter.eraseOp(rzOp);
       rewriter.eraseOp(hOp2);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/HXHToZ.cpp
+++ b/lib/Passes/Transforms/HXHToZ.cpp
@@ -30,7 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto hOp2 = dyn_cast_or_null<quake::HOp>(*op);
       if (!hOp2
@@ -68,7 +68,7 @@ public:
       rewriter.eraseOp(hOp1);
       rewriter.eraseOp(xOp);
       rewriter.eraseOp(hOp2);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/HXToZH.cpp
+++ b/lib/Passes/Transforms/HXToZH.cpp
@@ -29,7 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto xOp = dyn_cast_or_null<quake::XOp>(*op);
       if (!xOp
@@ -56,7 +56,7 @@ public:
       rewriter.create<quake::HOp>(loc, false, targets);
       rewriter.eraseOp(hOp);
       rewriter.eraseOp(xOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/HYToYH.cpp
+++ b/lib/Passes/Transforms/HYToYH.cpp
@@ -28,7 +28,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto yOp = dyn_cast_or_null<quake::YOp>(*op);
       if (!yOp
@@ -55,7 +55,7 @@ public:
       rewriter.create<quake::HOp>(loc, false, targets);
       rewriter.eraseOp(hOp);
       rewriter.eraseOp(yOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/HZHToX.cpp
+++ b/lib/Passes/Transforms/HZHToX.cpp
@@ -30,7 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto hOp2 = dyn_cast_or_null<quake::HOp>(*op);
       if (!hOp2
@@ -68,7 +68,7 @@ public:
       rewriter.eraseOp(hOp1);
       rewriter.eraseOp(zOp);
       rewriter.eraseOp(hOp2);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/HZToXH.cpp
+++ b/lib/Passes/Transforms/HZToXH.cpp
@@ -29,7 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto zOp = dyn_cast_or_null<quake::ZOp>(*op);
       if (!zOp
@@ -56,7 +56,7 @@ public:
       rewriter.create<quake::HOp>(loc, false, targets);
       rewriter.eraseOp(hOp);
       rewriter.eraseOp(zOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/NormalizeArgAngle.cpp
+++ b/lib/Passes/Transforms/NormalizeArgAngle.cpp
@@ -96,11 +96,11 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     OpBuilder builder(&kernel.getBody());
     kernel.walk([&](Operation *op) {
       if (normalizeAngleOfRotations(op, builder))
-        this->wasApplied = true;
+        this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/QuakeQMap.cpp
+++ b/lib/Passes/Transforms/QuakeQMap.cpp
@@ -247,7 +247,7 @@ public:
   void runOnOperation()
 
   override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     // Getting the function
     auto circuit = getOperation();
     // Get the function name
@@ -256,7 +256,7 @@ public:
         == std::string::npos)
       return; // do nothing if the function is not cudaq kernel
 
-    this->wasApplied = true;
+    this->wasApplied->store(true);
 
     std::map<int, int> measurements; // key: qubit, value register index
     int numQubits = getNumberOfQubits(circuit);

--- a/lib/Passes/Transforms/RxCxToCxRx.cpp
+++ b/lib/Passes/Transforms/RxCxToCxRx.cpp
@@ -30,7 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto cxOp = dyn_cast_or_null<quake::XOp>(*op);
       if (!cxOp
@@ -60,7 +60,7 @@ public:
       rewriter.create<quake::RxOp>(loc, parameters, ValueRange{}, targets);
       rewriter.eraseOp(rxOp);
       rewriter.eraseOp(cxOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/RxRxToRx.cpp
+++ b/lib/Passes/Transforms/RxRxToRx.cpp
@@ -29,7 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto rxOp2 = dyn_cast_or_null<quake::RxOp>(*op);
       if (!rxOp2
@@ -64,7 +64,7 @@ public:
       rewriter.create<quake::RxOp>(loc, params, ValueRange{}, targets);
       rewriter.eraseOp(rxOp1);
       rewriter.eraseOp(rxOp2);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/RyRyToRy.cpp
+++ b/lib/Passes/Transforms/RyRyToRy.cpp
@@ -27,7 +27,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto ryOp2 = dyn_cast_or_null<quake::RyOp>(*op);
       if (!ryOp2
@@ -62,7 +62,7 @@ public:
       rewriter.create<quake::RyOp>(loc, false, params, ValueRange{}, targets);
       rewriter.eraseOp(ryOp1);
       rewriter.eraseOp(ryOp2);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/RzRzToRz.cpp
+++ b/lib/Passes/Transforms/RzRzToRz.cpp
@@ -29,7 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto rzOp2 = dyn_cast_or_null<quake::RzOp>(*op);
       if (!rzOp2
@@ -64,7 +64,7 @@ public:
       rewriter.create<quake::RzOp>(loc, params, ValueRange{}, targets);
       rewriter.eraseOp(rzOp1);
       rewriter.eraseOp(rzOp2);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/SSSToSdg.cpp
+++ b/lib/Passes/Transforms/SSSToSdg.cpp
@@ -30,7 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto sOp3 = dyn_cast_or_null<quake::SOp>(*op);
       if (!sOp3
@@ -71,7 +71,7 @@ public:
       rewriter.eraseOp(sOp1);
       rewriter.eraseOp(sOp2);
       rewriter.eraseOp(sOp3);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/SSToZ.cpp
+++ b/lib/Passes/Transforms/SSToZ.cpp
@@ -30,7 +30,7 @@ public:
   StringRef getDescription() const override { return "Replace S S by Z"; }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto sOp2 = dyn_cast_or_null<quake::SOp>(*op);
       if (!sOp2
@@ -58,7 +58,7 @@ public:
       rewriter.create<quake::ZOp>(loc, false, targets);
       rewriter.eraseOp(sOp1);
       rewriter.eraseOp(sOp2);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/SZToSdg.cpp
+++ b/lib/Passes/Transforms/SZToSdg.cpp
@@ -30,7 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto zOp = dyn_cast_or_null<quake::ZOp>(*op);
       if (!zOp
@@ -57,7 +57,7 @@ public:
       rewriter.create<quake::SOp>(loc, true, targets);
       rewriter.eraseOp(sOp);
       rewriter.eraseOp(zOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/SdgSdgSdgToS.cpp
+++ b/lib/Passes/Transforms/SdgSdgSdgToS.cpp
@@ -32,7 +32,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto sOp3 = dyn_cast_or_null<quake::SOp>(*op);
       if (!sOp3
@@ -73,7 +73,7 @@ public:
       rewriter.eraseOp(sOp1);
       rewriter.eraseOp(sOp2);
       rewriter.eraseOp(sOp3);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/SdgSdgToZ.cpp
+++ b/lib/Passes/Transforms/SdgSdgToZ.cpp
@@ -29,7 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto sOp2 = dyn_cast_or_null<quake::SOp>(*op);
       if (!sOp2
@@ -57,7 +57,7 @@ public:
       rewriter.create<quake::ZOp>(loc, false, targets);
       rewriter.eraseOp(sOp1);
       rewriter.eraseOp(sOp2);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/SdgZToS.cpp
+++ b/lib/Passes/Transforms/SdgZToS.cpp
@@ -30,7 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto zOp = dyn_cast_or_null<quake::ZOp>(*op);
       if (!zOp
@@ -57,7 +57,7 @@ public:
       rewriter.create<quake::SOp>(loc, false, targets);
       rewriter.eraseOp(sOp);
       rewriter.eraseOp(zOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/TTToS.cpp
+++ b/lib/Passes/Transforms/TTToS.cpp
@@ -28,7 +28,7 @@ public:
   StringRef getDescription() const override { return "Replace T T by S"; }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto tOp2 = dyn_cast_or_null<quake::TOp>(*op);
       if (!tOp2
@@ -56,7 +56,7 @@ public:
       rewriter.create<quake::SOp>(loc, false, targets);
       rewriter.eraseOp(tOp1);
       rewriter.eraseOp(tOp2);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/XCxToCxX.cpp
+++ b/lib/Passes/Transforms/XCxToCxX.cpp
@@ -29,7 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto cxOp = dyn_cast_or_null<quake::XOp>(*op);
       if (!cxOp
@@ -57,7 +57,7 @@ public:
       rewriter.create<quake::XOp>(loc, false, targets);
       rewriter.eraseOp(xOp);
       rewriter.eraseOp(cxOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/XHToHZ.cpp
+++ b/lib/Passes/Transforms/XHToHZ.cpp
@@ -28,7 +28,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto hOp = dyn_cast_or_null<quake::HOp>(*op);
       if (!hOp
@@ -55,7 +55,7 @@ public:
       rewriter.create<quake::ZOp>(loc, false, targets);
       rewriter.eraseOp(xOp);
       rewriter.eraseOp(hOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/XHZToH.cpp
+++ b/lib/Passes/Transforms/XHZToH.cpp
@@ -29,7 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto zOp = dyn_cast_or_null<quake::ZOp>(*op);
       if (!zOp
@@ -67,7 +67,7 @@ public:
       rewriter.eraseOp(xOp);
       rewriter.eraseOp(hOp);
       rewriter.eraseOp(zOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/YHToHY.cpp
+++ b/lib/Passes/Transforms/YHToHY.cpp
@@ -27,7 +27,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto hOp = dyn_cast_or_null<quake::HOp>(*op);
       if (!hOp
@@ -54,7 +54,7 @@ public:
       rewriter.create<quake::YOp>(loc, false, target);
       rewriter.eraseOp(yOp);
       rewriter.eraseOp(hOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/ZCxToCxZ.cpp
+++ b/lib/Passes/Transforms/ZCxToCxZ.cpp
@@ -30,7 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto cxOp = dyn_cast_or_null<quake::XOp>(*op);
       if (!cxOp
@@ -59,7 +59,7 @@ public:
       rewriter.create<quake::ZOp>(loc, false, controls);
       rewriter.eraseOp(zOp);
       rewriter.eraseOp(cxOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/ZHToHX.cpp
+++ b/lib/Passes/Transforms/ZHToHX.cpp
@@ -29,7 +29,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto hOp = dyn_cast_or_null<quake::HOp>(*op);
       if (!hOp
@@ -56,7 +56,7 @@ public:
       rewriter.create<quake::XOp>(loc, false, target);
       rewriter.eraseOp(zOp);
       rewriter.eraseOp(hOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/ZHXToH.cpp
+++ b/lib/Passes/Transforms/ZHXToH.cpp
@@ -27,7 +27,7 @@ public:
   StringRef getDescription() const override { return "Fold Z H X to H"; }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto xOp = dyn_cast_or_null<quake::XOp>(*op);
       if (!xOp
@@ -65,7 +65,7 @@ public:
       rewriter.eraseOp(zOp);
       rewriter.eraseOp(hOp);
       rewriter.eraseOp(xOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/ZSToSdg.cpp
+++ b/lib/Passes/Transforms/ZSToSdg.cpp
@@ -30,7 +30,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto sOp = dyn_cast_or_null<quake::SOp>(*op);
       if (!sOp
@@ -57,7 +57,7 @@ public:
       rewriter.create<quake::SOp>(loc, true, target);
       rewriter.eraseOp(zOp);
       rewriter.eraseOp(sOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };

--- a/lib/Passes/Transforms/ZSdgToS.cpp
+++ b/lib/Passes/Transforms/ZSdgToS.cpp
@@ -28,7 +28,7 @@ public:
   }
 
   void operationsOnQuantumKernel(FuncOp kernel) override {
-    this->wasApplied = false;
+    this->wasApplied->store(false);
     kernel.walk([&](Operation *op) {
       auto sOp = dyn_cast_or_null<quake::SOp>(*op);
       if (!sOp
@@ -55,7 +55,7 @@ public:
       rewriter.create<quake::SOp>(loc, false, target);
       rewriter.eraseOp(zOp);
       rewriter.eraseOp(sOp);
-      this->wasApplied = true;
+      this->wasApplied->store(true);
     });
   }
 };


### PR DESCRIPTION
## Summary
- replace direct assignments to `wasApplied` with atomic `store` calls in all cancellation, transformation, and decomposition passes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f51b305db48332aa3e638f58f4fa44