### PR TITLE
Fix environment cache reset and async step accounting

### DIFF
--- a/AI/include/Environment/Wrappers/normalize_reward.hpp
+++ b/AI/include/Environment/Wrappers/normalize_reward.hpp
@@ -20,6 +20,9 @@ public:
   /// Destructor
   ~NormalizeReward() override = default;
 
+  /// Reset environment and reward normalization state
+  void reset();
+
   /// Copy and Move constructors and assignments
   NormalizeReward(const NormalizeReward &other) = delete;
   NormalizeReward &operator=(const NormalizeReward &other) = delete;
@@ -32,6 +35,9 @@ public:
    * @return
    */
   std::tuple<float, bool, bool> step(unsigned int action) override;
+
+private:
+  void reset_normalization_state();
 };
 } // namespace ai_pass_selector
 

--- a/AI/src/Environment/Wrappers/normalize_reward.cpp
+++ b/AI/src/Environment/Wrappers/normalize_reward.cpp
@@ -6,6 +6,12 @@ NormalizeReward::NormalizeReward(const QuantumCircuitEnvironment &environment)
   this->circuit_path = environment.getCircuitPath();
   std::tie(this->qubits_cholesky_params, this->gates_weights) =
       environment.getRegisteredRandomizerParams();
+  this->reset_normalization_state();
+}
+
+void NormalizeReward::reset() {
+  QuantumCircuitEnvironment::reset();
+  this->reset_normalization_state();
 }
 
 std::tuple<float, bool, bool> NormalizeReward::step(unsigned int action) {
@@ -30,6 +36,13 @@ std::tuple<float, bool, bool> NormalizeReward::step(unsigned int action) {
   return {
       static_cast<float>(reward / std::sqrt(this->variance + this->epsilon)),
       terminated, truncated};
+}
+
+void NormalizeReward::reset_normalization_state() {
+  this->discounted_reward = 0.0;
+  this->count = 0u;
+  this->mean = 0.0;
+  this->variance = 1.0;
 }
 
 } // namespace ai_pass_selector

--- a/AI/src/Environment/quantum_circuit_environment.cpp
+++ b/AI/src/Environment/quantum_circuit_environment.cpp
@@ -85,6 +85,7 @@ void QuantumCircuitEnvironment::clear(bool hard) {
     this->qubits_cholesky_params = std::nullopt;
     this->gates_weights = std::nullopt;
   }
+  this->latest_observation = std::nullopt;
   this->circuit.clear();
   this->step_per_episode = 0u;
   this->step_no_improvement = 0u;

--- a/AI/src/NeuralNetworks/Agents/A3C/a3c_trainer.cpp
+++ b/AI/src/NeuralNetworks/Agents/A3C/a3c_trainer.cpp
@@ -119,6 +119,7 @@ train_a3c(const std::unique_ptr<BaseA3CAgent> &agent_boss,
 
           double total_worker_reward = 0.0;
           unsigned int update_step;
+          unsigned int steps_taken = 0u;
           bool add_bootstrap = false;
           for (update_step = 0u; update_step < max_steps_per_episode;
                update_step++) {
@@ -134,6 +135,7 @@ train_a3c(const std::unique_ptr<BaseA3CAgent> &agent_boss,
             auto [reward, terminated, truncated] =
                 environment.step(action.item<int>());
             total_worker_reward += reward;
+            steps_taken++;
 
             episode_log_probs_vector.push_back(log_action_probs);
             episode_values_vector.push_back(state_values);
@@ -183,7 +185,7 @@ train_a3c(const std::unique_ptr<BaseA3CAgent> &agent_boss,
           agent_boss->update_parameters_assuming_gradients_are_loaded();
           {
             std::lock_guard lock(*global_mutex);
-            global_async_step += update_step;
+            global_async_step += steps_taken;
             global_max_reward =
                 std::max(global_max_reward, total_worker_reward);
             updateProgress(


### PR DESCRIPTION
## Summary
- clear the cached observation when the quantum circuit environment is cleared
- reset reward normalization statistics whenever the NormalizeReward wrapper is reset
- count the actual steps taken when updating the A3C global async step counter

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f52915e55483328ac3680bb951184e