### PR TITLE
Fix random circuit gate weight adjustments

### DIFF
--- a/AI/include/Environment/random_quantum_circuit_generator.hpp
+++ b/AI/include/Environment/random_quantum_circuit_generator.hpp
@@ -111,9 +111,9 @@ get_nr_qubits_gates_operations_measurements(
  * @param subset_size
  * @param gates_weights
  */
-void addjust_gates_weights(
+void adjust_gates_weights(
     double multiplier, unsigned int subset_size,
-    std::array<unsigned int, GATES_WEIGHTS_SIZE> gates_weights);
+    std::array<unsigned int, GATES_WEIGHTS_SIZE> &gates_weights);
 
 /**
  *

--- a/AI/src/Environment/random_quantum_circuit_generator.cpp
+++ b/AI/src/Environment/random_quantum_circuit_generator.cpp
@@ -280,7 +280,7 @@ get_nr_qubits_gates_operations_measurements(
 
 void adjust_gates_weights(
     double multiplier, unsigned int subset_size,
-    std::array<unsigned int, GATES_WEIGHTS_SIZE> gates_weights) {
+    std::array<unsigned int, GATES_WEIGHTS_SIZE> &gates_weights) {
   if (multiplier > 0.0) {
     unsigned int minimum_weight = std::numeric_limits<unsigned int>::max();
     for (unsigned int i = 0; i < subset_size; i++) {


### PR DESCRIPTION
## Summary
- fix the adjust_gates_weights declaration typo in the random circuit generator header
- pass the gates weight array by reference so weight adjustments persist

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f88643a5288332b1128c5451448e93