### PR TITLE
Fix agent evaluation sampling and null handling

### DIFF
--- a/AI/src/NeuralNetworks/Agents/training_and_run_manager.cpp
+++ b/AI/src/NeuralNetworks/Agents/training_and_run_manager.cpp
@@ -14,8 +14,10 @@
 
 // Stdandard library includes
 #include <nlohmann/json.hpp>
+#include <random>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 namespace fs = std::filesystem;
 
@@ -77,7 +79,8 @@ evaluate(const std::string &agent_name, const std::string &dataset_name,
   if (sampled) {
     unsigned int nr_sampled_files = max_circuits.value();
     // TODO: Pick random nr_files files
-    std::discrete_distribution<unsigned int> distribution(0u, nr_files - 1);
+    std::uniform_int_distribution<unsigned int> distribution(0u,
+                                                             nr_files - 1);
     std::unordered_set<unsigned int> sampled_indices;
     std::vector<fs::path> sampled_files;
     sampled_files.reserve(nr_sampled_files);
@@ -96,6 +99,12 @@ evaluate(const std::string &agent_name, const std::string &dataset_name,
             << dataset_name << " with " << nr_files << " circuits."
             << std::endl;
   std::unique_ptr<AbstractAgent> agent = AbstractAgent::getAgent(agent_name);
+  if (!agent) {
+    std::cerr << "Failed to construct agent " << agent_name << "."
+              << std::endl;
+    return {};
+  }
+
   agent->load_model();
   std::vector<std::tuple<std::string, int, int>> circuit_optimization_results;
   double avg_nr_gates_reduction = 0.0;


### PR DESCRIPTION
## Summary
- switch evaluation sampling to use a uniform integer distribution
- guard against null agents returned from AbstractAgent::getAgent
- add the required standard headers for the updated logic

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f898dbd5c483328fc7a5b70b8d2559