### PR TITLE
Fix agent parameter counting and evaluation sampling

### DIFF
--- a/AI/include/NeuralNetworks/Agents/abstract_agent.hpp
+++ b/AI/include/NeuralNetworks/Agents/abstract_agent.hpp
@@ -25,7 +25,6 @@ class AbstractAgent : public torch::nn::Module {
 protected:
   /// Attributes on configuration
   unsigned int max_qubits = 0u;
-  unsigned int nr_trainable_parmaeters = 0u;
 
   /// Mutex for thread safety
   std::unique_ptr<std::mutex> model_mutex = std::make_unique<std::mutex>();

--- a/AI/src/NeuralNetworks/Agents/abstract_agent.cpp
+++ b/AI/src/NeuralNetworks/Agents/abstract_agent.cpp
@@ -21,14 +21,12 @@ namespace ai_pass_selector {
 extern std::unordered_map<std::string, PassSelectorRuntimeParam> GLOBAL_PARAMS;
 
 AbstractAgent::AbstractAgent(unsigned int max_qubits)
-    : max_qubits(std::max(max_qubits, GLOBAL_MIN_NR_QUBITS)) {
-  this->nr_trainable_parmaeters = count_nr_trainable_parameters(*this);
-}
+    : max_qubits(std::max(max_qubits, GLOBAL_MIN_NR_QUBITS)) {}
 
 unsigned int AbstractAgent::getMaxQubits() const { return this->max_qubits; }
 
 unsigned int AbstractAgent::getNrTrainableParameters() const {
-  return this->nr_trainable_parmaeters;
+  return count_nr_trainable_parameters(*this);
 }
 
 std::tuple<QuantumCircuit, int, int> AbstractAgent::run_on_circuit(

--- a/AI/src/NeuralNetworks/Agents/training_and_run_manager.cpp
+++ b/AI/src/NeuralNetworks/Agents/training_and_run_manager.cpp
@@ -14,8 +14,10 @@
 
 // Stdandard library includes
 #include <nlohmann/json.hpp>
+#include <random>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 namespace fs = std::filesystem;
 
@@ -72,12 +74,16 @@ evaluate(const std::string &agent_name, const std::string &dataset_name,
   if (files.empty()) {
     return {};
   }
-  unsigned int nr_files = files.size();
+  unsigned int nr_files = static_cast<unsigned int>(files.size());
   bool sampled = max_circuits.has_value() && max_circuits.value() < nr_files;
   if (sampled) {
     unsigned int nr_sampled_files = max_circuits.value();
+    if (nr_sampled_files == 0u) {
+      std::cerr << "Cannot evaluate on zero circuits." << std::endl;
+      return {};
+    }
     // TODO: Pick random nr_files files
-    std::discrete_distribution<unsigned int> distribution(0u, nr_files - 1);
+    std::uniform_int_distribution<unsigned int> distribution(0u, nr_files - 1);
     std::unordered_set<unsigned int> sampled_indices;
     std::vector<fs::path> sampled_files;
     sampled_files.reserve(nr_sampled_files);
@@ -96,6 +102,11 @@ evaluate(const std::string &agent_name, const std::string &dataset_name,
             << dataset_name << " with " << nr_files << " circuits."
             << std::endl;
   std::unique_ptr<AbstractAgent> agent = AbstractAgent::getAgent(agent_name);
+  if (!agent) {
+    std::cerr << "Failed to create agent '" << agent_name
+              << "' for evaluation." << std::endl;
+    return {};
+  }
   agent->load_model();
   std::vector<std::tuple<std::string, int, int>> circuit_optimization_results;
   double avg_nr_gates_reduction = 0.0;
@@ -115,8 +126,10 @@ evaluate(const std::string &agent_name, const std::string &dataset_name,
     avg_depth_reduction += depth_reduction;
   }
   std::cout << std::endl;
-  avg_nr_gates_reduction /= nr_files;
-  avg_depth_reduction /= nr_files;
+  if (nr_files > 0u) {
+    avg_nr_gates_reduction /= nr_files;
+    avg_depth_reduction /= nr_files;
+  }
   nlohmann::ordered_json json_file;
   json_file["dataset_name"] = dataset_name;
   json_file["agent"] = agent_name;


### PR DESCRIPTION
## Summary
- compute trainable parameter counts lazily to avoid stale cached values
- fix evaluation sampling to select random circuits uniformly and guard agent creation failures
- prevent evaluation from proceeding with zero sampled circuits

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f89fcab1c48332ab5147036016800a