### PR TITLE
Guard depth calculation against missing alloc

### DIFF
--- a/lib/Support/mlir_utils.cpp
+++ b/lib/Support/mlir_utils.cpp
@@ -179,6 +179,10 @@ getQubitsInstructionsDepth(FuncOp circuit) {
       depths[qubit] = max_depth + 1;
     }
   });
+  if (depths.empty()) {
+    // If a malformed kernel skips allocation entirely, we assume zero depth.
+    return {nr_qubits, nr_gates, 0};
+  }
   return {nr_qubits, nr_gates, *std::ranges::max_element(depths)};
 }
 


### PR DESCRIPTION
## Summary
- avoid dereferencing max_element when no quake allocation is present
- return zero depth while documenting the malformed kernel assumption

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f8dea9a80083329a641481925aa79a