### PR TITLE
Fix SDSAC loss computation and rollout bookkeeping

### DIFF
--- a/AI/include/NeuralNetworks/Agents/SDSAC/base_sdsac_agent.hpp
+++ b/AI/include/NeuralNetworks/Agents/SDSAC/base_sdsac_agent.hpp
@@ -100,20 +100,27 @@ public:
    * @param old_entropy
    * @param new_entropy
    * @param reward
-   * @param actions
+   * @param old_action
    * @param Q1_main
    * @param Q2_main
    * @param Q1_avg
    * @param Q2_avg
+   * @param next_action_probs
+   * @param next_Q1_avg
+   * @param next_Q2_avg
+   * @param done
    * @return [actor_loss, critic_Q1_loss, critic_Q2_loss,
    * optional_temperature_alpha_loss]
    */
   std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
   get_loss(const torch::Tensor &new_action_probs,
            const torch::Tensor &old_entropy, const torch::Tensor &new_entropy,
-           const torch::Tensor &reward, const torch::Tensor &actions,
+           const torch::Tensor &reward, const torch::Tensor &old_action,
            const torch::Tensor &Q1_main, const torch::Tensor &Q2_main,
-           const torch::Tensor &Q1_avg, const torch::Tensor &Q2_avg);
+           const torch::Tensor &Q1_avg, const torch::Tensor &Q2_avg,
+           const torch::Tensor &next_action_probs,
+           const torch::Tensor &next_Q1_avg, const torch::Tensor &next_Q2_avg,
+           const torch::Tensor &done);
 
   /**
    *

--- a/AI/include/NeuralNetworks/Agents/SDSAC/sdsac_trainer.hpp
+++ b/AI/include/NeuralNetworks/Agents/SDSAC/sdsac_trainer.hpp
@@ -13,6 +13,7 @@ struct SDSAC_EpisodeRollout {
   torch::Tensor actions;                   // [T]
   torch::Tensor rewards;                   // [T]
   torch::Tensor entropies;                 // [T]
+  torch::Tensor dones;                     // [T]
 };
 
 /**

--- a/AI/src/NeuralNetworks/Agents/SDSAC/base_sdsac_agent.cpp
+++ b/AI/src/NeuralNetworks/Agents/SDSAC/base_sdsac_agent.cpp
@@ -138,37 +138,58 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
 BaseSDSACAgent::get_loss(
     const torch::Tensor &new_action_probs, const torch::Tensor &old_entropy,
     const torch::Tensor &new_entropy, const torch::Tensor &reward,
-    const torch::Tensor &actions, const torch::Tensor &Q1_main,
+    const torch::Tensor &old_action, const torch::Tensor &Q1_main,
     const torch::Tensor &Q2_main, const torch::Tensor &Q1_avg,
-    const torch::Tensor &Q2_avg) {
-  int32_t action_index = actions.item<int32_t>();
-  torch::Tensor log_action_probs = new_action_probs.log();
-  torch::Tensor expectation_Q1 = new_action_probs.dot(
-      Q1_avg - this->sdsac_temperature_alpha * log_action_probs);
-  torch::Tensor expectation_Q2 = new_action_probs.dot(
-      Q2_avg - this->sdsac_temperature_alpha * log_action_probs);
-  torch::Tensor y = reward + this->discount_factor * 0.5 *
-                                 (expectation_Q1 + expectation_Q2).detach();
-  torch::Tensor clip_value_Q1 =
-      torch::clamp(/*self=*/Q1_main[action_index] - Q1_avg[action_index],
-                   /*min=*/-this->sdsac_clip_c, /*max=*/this->sdsac_clip_c);
-  torch::Tensor clip_value_Q2 =
-      torch::clamp(/*self=*/Q2_main[action_index] - Q2_avg[action_index],
-                   /*min=*/-this->sdsac_clip_c, /*max=*/this->sdsac_clip_c);
-  torch::Tensor target_entropy = torch::tensor(new_action_probs.size(0)).log();
-  return {/*actor_loss=*/new_action_probs.dot(
-              this->sdsac_temperature_alpha * log_action_probs -
-              torch::min(Q1_main, Q2_main).detach()) +
-              0.5 * this->sdsac_penalty_beta *
-                  (old_entropy - new_entropy).pow(2),
-          /*critic_Q1_loss=*/
-          torch::max((Q1_main[action_index] - y).pow(2),
-                     (Q1_avg[action_index] + clip_value_Q1 - y).pow(2)),
-          /*critic_Q1_loss=*/
-          torch::max((Q2_main[action_index] - y).pow(2),
-                     (Q2_avg[action_index] + clip_value_Q2 - y).pow(2)),
-          /*alpha_loss=*/-this->sdsac_temperature_alpha *
-              new_action_probs.dot(log_action_probs + target_entropy).detach()};
+    const torch::Tensor &Q2_avg, const torch::Tensor &next_action_probs,
+    const torch::Tensor &next_Q1_avg, const torch::Tensor &next_Q2_avg,
+    const torch::Tensor &done) {
+  auto log_action_probs = new_action_probs.log();
+  auto action_index = old_action.to(torch::kLong);
+  auto Q1_main_at =
+      Q1_main.gather(/*dim=*/-1, action_index.unsqueeze(0)).squeeze(-1);
+  auto Q2_main_at =
+      Q2_main.gather(/*dim=*/-1, action_index.unsqueeze(0)).squeeze(-1);
+  auto Q1_avg_at =
+      Q1_avg.gather(/*dim=*/-1, action_index.unsqueeze(0)).squeeze(-1);
+  auto Q2_avg_at =
+      Q2_avg.gather(/*dim=*/-1, action_index.unsqueeze(0)).squeeze(-1);
+
+  bool done_bool = done.item<bool>();
+  torch::Tensor y = reward;
+  if (!done_bool) {
+    auto next_log_action_probs = next_action_probs.log();
+    auto expectation_Q1 = next_action_probs.detach().dot(
+        next_Q1_avg.detach() -
+        this->sdsac_temperature_alpha.detach() *
+            next_log_action_probs.detach());
+    auto expectation_Q2 = next_action_probs.detach().dot(
+        next_Q2_avg.detach() -
+        this->sdsac_temperature_alpha.detach() *
+            next_log_action_probs.detach());
+    y = y + this->discount_factor *
+                0.5 * (expectation_Q1 + expectation_Q2);
+  }
+
+  auto clip_value_Q1 = torch::clamp(
+      Q1_main_at - Q1_avg_at.detach(), -this->sdsac_clip_c, this->sdsac_clip_c);
+  auto clip_value_Q2 = torch::clamp(
+      Q2_main_at - Q2_avg_at.detach(), -this->sdsac_clip_c, this->sdsac_clip_c);
+  auto target_entropy =
+      torch::tensor(static_cast<double>(new_action_probs.size(0)),
+                    new_action_probs.options())
+          .log();
+  return {
+      /*actor_loss=*/new_action_probs.dot(
+          this->sdsac_temperature_alpha * log_action_probs -
+          torch::min(Q1_main, Q2_main).detach()) +
+          0.5 * this->sdsac_penalty_beta *
+              (old_entropy - new_entropy).pow(2),
+      /*critic_Q1_loss=*/torch::max((Q1_main_at - y).pow(2),
+                                    (Q1_avg_at + clip_value_Q1 - y).pow(2)),
+      /*critic_Q2_loss=*/torch::max((Q2_main_at - y).pow(2),
+                                    (Q2_avg_at + clip_value_Q2 - y).pow(2)),
+      /*alpha_loss=*/-this->sdsac_temperature_alpha *
+          new_action_probs.dot(log_action_probs + target_entropy).detach()};
 }
 
 void BaseSDSACAgent::sdsac_update_parameters(

--- a/AI/src/NeuralNetworks/Agents/SDSAC/sdsac_trainer.cpp
+++ b/AI/src/NeuralNetworks/Agents/SDSAC/sdsac_trainer.cpp
@@ -10,6 +10,7 @@
 // Standard library includes
 #include <csignal>
 #include <filesystem>
+#include <tuple>
 
 namespace fs = std::filesystem;
 
@@ -77,10 +78,12 @@ train_sdsac(const std::unique_ptr<BaseSDSACAgent> &agent,
       std::vector<torch::Tensor> actions_vector;
       std::vector<torch::Tensor> rewards_vector;
       std::vector<torch::Tensor> entropies_vector;
+      std::vector<torch::Tensor> dones_vector;
       rollout_new.observations.reserve(T + 1);
       actions_vector.reserve(T);
       rewards_vector.reserve(T);
       entropies_vector.reserve(T);
+      dones_vector.reserve(T);
 
       unsigned int update_step;
       for (update_step = 0u; update_step < max_steps_per_episode;
@@ -106,6 +109,9 @@ train_sdsac(const std::unique_ptr<BaseSDSACAgent> &agent,
         auto [reward, terminated, truncated] =
             environment.step(action.item<int>());
         rewards_vector.push_back(torch::tensor(reward, options));
+        dones_vector.push_back(torch::tensor(
+            static_cast<bool>(terminated || truncated),
+            torch::TensorOptions().dtype(torch::kBool)));
         total_episode_reward += reward;
         if (truncated || terminated) {
           break;
@@ -116,6 +122,7 @@ train_sdsac(const std::unique_ptr<BaseSDSACAgent> &agent,
       rollout_new.actions = torch::stack(actions_vector).to(device);
       rollout_new.rewards = torch::stack(rewards_vector).to(device);
       rollout_new.entropies = torch::stack(entropies_vector).to(device);
+      rollout_new.dones = torch::stack(dones_vector);
 
       //////////////////////////////////////////////////////////////////////////
       /// Inner loop 2: Rollout B
@@ -143,6 +150,11 @@ train_sdsac(const std::unique_ptr<BaseSDSACAgent> &agent,
         auto [action_probs, Q1_main, Q2_main, Q1_avg, Q2_avg] =
             agent->sdsac_forward(
                 /*observation=*/rollout_old.observations[update_step]);
+        auto next_forward = agent->sdsac_forward(
+            /*observation=*/rollout_old.observations[update_step + 1]);
+        auto next_action_probs = std::get<0>(next_forward);
+        auto next_Q1_avg = std::get<3>(next_forward);
+        auto next_Q2_avg = std::get<4>(next_forward);
         auto [actor_loss, critic_Q1_loss, critic_Q2_loss,
               optional_temperature_alpha_loss] =
             agent->get_loss(
@@ -153,11 +165,15 @@ train_sdsac(const std::unique_ptr<BaseSDSACAgent> &agent,
                      .sum(/*dim=*/-1)
                      .squeeze(-1),
                 /*rewards=*/rollout_old.rewards[update_step],
-                /*actions=*/rollout_old.actions[update_step],
+                /*old_action=*/rollout_old.actions[update_step],
                 /*Q1_main=*/Q1_main,
                 /*Q2_main=*/Q2_main,
-                /*Q1_avg=*/Q1_avg.detach(),
-                /*Q2_avg=*/Q2_avg.detach());
+                /*Q1_avg=*/Q1_avg,
+                /*Q2_avg=*/Q2_avg,
+                /*next_action_probs=*/next_action_probs,
+                /*next_Q1_avg=*/next_Q1_avg,
+                /*next_Q2_avg=*/next_Q2_avg,
+                /*done=*/rollout_old.dones[update_step]);
         updateProgresses(
             {{episode_idx, nr_episodes}, {update_step + 1, steps_in_episode}},
             /*display_message=*/"Rollout B | Reward: " +


### PR DESCRIPTION
## Summary
- compute critic targets using action-specific Q values and next-state expectations
- pass stored rollout actions and terminal flags through the trainer to the loss function
- detach target expectations correctly while preserving policy gradients

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911e5ebaf988332a5d17503f5e0e849)